### PR TITLE
Added new configuration option pid_file.

### DIFF
--- a/lib/generators/templates/rapns.yml
+++ b/lib/generators/templates/rapns.yml
@@ -15,3 +15,4 @@ production:
   airbrake_notify: true
   poll: 2
   connections: 3
+  pid_file: tmp/pids/rapns.pid

--- a/lib/rapns/daemon/configuration.rb
+++ b/lib/rapns/daemon/configuration.rb
@@ -5,7 +5,7 @@ module Rapns
 
   module Daemon
     class Configuration
-      attr_accessor :host, :port, :certificate, :certificate_password, :poll, :airbrake_notify, :connections
+      attr_accessor :host, :port, :certificate, :certificate_password, :poll, :airbrake_notify, :connections, :pid_file
       alias_method  :airbrake_notify?, :airbrake_notify
 
       def initialize(environment, config_path)
@@ -24,6 +24,7 @@ module Rapns
         set_variable(:certificate_password, config, :optional => true, :default => "")
         set_variable(:poll, config, :optional => true, :default => 2)
         set_variable(:connections, config, :optional => true, :default => 3)
+        set_variable(:pid_file, config, :optional => true, :default => "")
       end
 
       def certificate

--- a/spec/rapns/daemon/configuration_spec.rb
+++ b/spec/rapns/daemon/configuration_spec.rb
@@ -5,7 +5,7 @@ describe Rapns::Daemon::Configuration do
   end
 
   before do
-    @config = {"port" => 123, "host" => "localhost", "certificate" => "production.pem", "certificate_password" => "abc123", "airbrake_notify" => false, "poll" => 4, "connections" => 6}
+    @config = {"port" => 123, "host" => "localhost", "certificate" => "production.pem", "certificate_password" => "abc123", "airbrake_notify" => false, "poll" => 4, "connections" => 6, "pid_file" => "rapns.pid"}
   end
 
   it "should raise an error if the configuration file does not exist" do
@@ -121,5 +121,12 @@ describe Rapns::Daemon::Configuration do
     configuration.stub(:read_config).and_return({"production" => @config})
     configuration.load
     configuration.certificate.should == "/different_path/to/production.pem"
+  end
+  
+  it "should set the PID file path" do
+    configuration = Rapns::Daemon::Configuration.new("production", "/some/config.yml")
+    configuration.stub(:read_config).and_return({"production" => @config})
+    configuration.load
+    configuration.pid_file.should == "rapns.pid"
   end
 end

--- a/spec/rapns/daemon_spec.rb
+++ b/spec/rapns/daemon_spec.rb
@@ -8,7 +8,7 @@ describe Rapns::Daemon, "when starting" do
     Rails.stub(:root).and_return("/rails_root")
 
     @configuration = Rapns::Daemon::Configuration.new("development", "/rails_root/config/rapns/rapns.yml")
-    @configuration.stub(:read_config).and_return({"development" => {"port" => 123, "host" => "localhost", "certificate" => "development.pem", "certificate_password" => "abc123"}})
+    @configuration.stub(:read_config).and_return({"development" => {"port" => 123, "host" => "localhost", "certificate" => "development.pem", "certificate_password" => "abc123", "pid_file" => "rapns.pid"}})
     Rapns::Daemon::Configuration.stub(:new).and_return(@configuration)
 
     @certificate = Rapns::Daemon::Certificate.new("/rails_root/config/rapns/development.pem")
@@ -26,6 +26,7 @@ describe Rapns::Daemon, "when starting" do
     Rapns::Daemon::Feeder.stub(:start)
     Rapns::Daemon::Feeder.stub(:wait)
     Rapns::Daemon.stub(:daemonize)
+    Rapns::Daemon.stub(:write_pid_file)
     @logger = mock("Logger")
     Rapns::Daemon::Logger.stub(:new).and_return(@logger)
   end
@@ -91,6 +92,11 @@ describe Rapns::Daemon, "when starting" do
     Rapns::Daemon.should_not_receive(:daemonize)
     Rapns::Daemon.start("development", true)
   end
+  
+  it "should write the process ID to the PID file" do
+    Rapns::Daemon.should_receive(:write_pid_file)
+    Rapns::Daemon.start("development", {})
+  end
 
   it "should start the feeder" do
     Rapns::Daemon::Feeder.should_receive(:start)
@@ -143,6 +149,18 @@ describe Rapns::Daemon, "when being shutdown" do
   it "should not attempt to drain the delivery handler pool if it has not been initialized" do
     Rapns::Daemon.stub(:delivery_handler_pool).and_return(nil)
     @handler_pool.should_not_receive(:drain)
+    Rapns::Daemon.send(:shutdown)
+  end
+  
+  it "should remove the PID file if one was written" do
+    Rapns::Daemon.stub(:pid_file).and_return("rapns.pid")
+    File.should_receive(:delete).with("rapns.pid")
+    Rapns::Daemon.send(:shutdown)
+  end
+  
+  it "should not remove the PID file if one was not written" do
+    Rapns::Daemon.stub(:pid_file).and_return(nil)
+    File.should_not_receive(:delete)
     Rapns::Daemon.send(:shutdown)
   end
 end


### PR DESCRIPTION
This adds a new configuration option, "pid-file". The default is empty, and in this case, the behavior of rapns is unchanged.

With a setting, though, rapns will write the main PID to the named file at startup, after daemonizing if appropriate. At shutdown, the PID file is deleted. If the file does not start with "/", it is created relative to Rails.root.

I also added SIGTERM to the set of captured signals so that a argument-less 'kill' will cleanly shut down the process and remove the PID file.
