### PR TITLE
Rescue SSL Errors and Trigger Reconnect Logic

### DIFF
--- a/lib/rapns/daemon/connection.rb
+++ b/lib/rapns/daemon/connection.rb
@@ -39,7 +39,7 @@ module Rapns
           @ssl_socket.flush
 
           check_for_error
-        rescue Errno::EPIPE => e
+        rescue Errno::EPIPE, OpenSSL::SSL::SSLError => e
           Rapns::Daemon.logger.error("[#{@name}] Lost connection to #{Rapns::Daemon.configuration.host}:#{Rapns::Daemon.configuration.port}, reconnecting...")
           @tcp_socket, @ssl_socket = connect_socket
 


### PR DESCRIPTION
With the rapns push notification server running over night, I am seeing a huge flood of Airbrakes and a stalled daemon when I wake up in the morning. Looking at the backtrace, the error is a **OpenSSL::SSL::SSLError: SSL_write:: bad write retry** coming from:

```
/usr/local/lib/ruby/1.9.1/openssl/buffering.rb:235:in `syswrite'
/usr/local/lib/ruby/1.9.1/openssl/buffering.rb:235:in `do_write'
/usr/local/lib/ruby/1.9.1/openssl/buffering.rb:249:in `write'
vendor/bundle/ruby/1.9.1/bundler/gems/rapns-fbcb5164c4bc/lib/rapns/daemon/connection.rb:38:in `write'
vendor/bundle/ruby/1.9.1/bundler/gems/rapns-fbcb5164c4bc/lib/rapns/daemon/delivery_handler.rb:28:in `block in handle_next_notification'
```

I have added this SSLError to the connection retry logic in the connection.rb code and updated the specs.
