### PR TITLE
Adds support for dictionary alert properties

### DIFF
--- a/lib/rapns/notification.rb
+++ b/lib/rapns/notification.rb
@@ -13,6 +13,19 @@ module Rapns
     def device_token=(token)
       write_attribute(:device_token, token.delete(" <>")) if !token.nil?
     end
+    
+    def alert=(alert)
+      if alert.is_a?(Hash)
+        write_attribute(:alert, ActiveSupport::JSON.encode(alert))
+      else
+        write_attribute(:alert, alert)
+      end
+    end
+    
+    def alert
+      string_or_json = read_attribute(:alert)
+      ActiveSupport::JSON.decode(string_or_json) rescue string_or_json
+    end
 
     def attributes_for_device=(attrs)
       raise ArgumentError, "attributes_for_device must be a Hash" if !attrs.is_a?(Hash)

--- a/spec/rapns/notification_spec.rb
+++ b/spec/rapns/notification_spec.rb
@@ -68,6 +68,11 @@ describe Rapns::Notification, "as_json" do
     notification.as_json["aps"].key?("alert").should be_false
   end
 
+  it "should encode the alert as JSON if it is a Hash" do
+    notification = Rapns::Notification.new(:alert => { 'body' => "hi mom", 'alert-loc-key' => "View" })
+    notification.as_json["aps"]["alert"].should == { 'body' => "hi mom", 'alert-loc-key' => "View" }
+  end
+
   it "should include the badge if present" do
     notification = Rapns::Notification.new(:badge => 6)
     notification.as_json["aps"]["badge"].should == 6


### PR DESCRIPTION
This implements support for the `alert` child properties in [Table 3-2](http://developer.apple.com/library/ios/#documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/ApplePushService/ApplePushService.html#//apple_ref/doc/uid/TP40008194-CH100-SW1) of the Local and Push Notification Programming Guide.
