### PR TITLE
Payload size fix: the 256 bytes limitation is on payload but not the entire packet

### DIFF
--- a/lib/rapns/binary_notification_validator.rb
+++ b/lib/rapns/binary_notification_validator.rb
@@ -2,7 +2,7 @@ module Rapns
   class BinaryNotificationValidator < ActiveModel::Validator
 
     def validate(record)
-      if record.to_binary(:for_validation => true).size > 256
+      if record.payload_size > 256
         record.errors[:base] << "APN notification cannot be larger than 256 bytes. Try condensing your alert and device attributes."
       end
     end

--- a/lib/rapns/binary_notification_validator.rb
+++ b/lib/rapns/binary_notification_validator.rb
@@ -3,7 +3,7 @@ module Rapns
 
     def validate(record)
       if record.payload_size > 256
-        record.errors[:base] << "APN notification cannot be larger than 256 bytes. Try condensing your alert and device attributes."
+        record.errors[:base] << "APN notification payload cannot be larger than 256 bytes. Try condensing your alert attribute."
       end
     end
   end

--- a/lib/rapns/daemon/feedback_receiver.rb
+++ b/lib/rapns/daemon/feedback_receiver.rb
@@ -44,7 +44,7 @@ module Rapns
 
       def self.parse_tuple(tuple)
         failed_at, _, device_token = tuple.unpack("N1n1H*")
-        [Time.at(failed_at), device_token]
+        [Time.at(failed_at).utc, device_token]
       end
 
       def self.create_feedback(failed_at, device_token)

--- a/lib/rapns/notification.rb
+++ b/lib/rapns/notification.rb
@@ -58,12 +58,19 @@ module Rapns
       json
     end
 
+    def payload
+      as_json.to_json
+    end
+
+    def payload_size
+      payload.bytesize
+    end
+
     # This method conforms to the enhanced binary format.
     # http://developer.apple.com/library/ios/#documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingWIthAPS/CommunicatingWIthAPS.html#//apple_ref/doc/uid/TP40008194-CH101-SW4
     def to_binary(options = {})
       id_for_pack = options[:for_validation] ? 0 : id
-      json = as_json.to_json
-      [1, id_for_pack, expiry, 0, 32, device_token, 0, json.size, json].pack("cNNccH*cca*")
+      [1, id_for_pack, expiry, 0, 32, device_token, 0, payload_size, payload].pack("cNNccH*cca*")
     end
   end
 end

--- a/spec/rapns/notification_spec.rb
+++ b/spec/rapns/notification_spec.rb
@@ -130,3 +130,16 @@ describe Rapns::Notification, "bug #31" do
     notification.alert.should == {"one" => 2}
   end
 end
+
+describe Rapns::Notification, "payload size limitation" do
+  it "should limit payload size to 256 bytes but not the entire packet" do
+    notification = Rapns::Notification.new do |n|
+      n.device_token = "a" * 64
+      n.alert = "a" * 210
+    end
+
+    notification.to_binary(:for_validation => true).size.should > 256
+    notification.payload_size.should < 256
+    notification.should be_valid
+  end
+end

--- a/spec/rapns/notification_spec.rb
+++ b/spec/rapns/notification_spec.rb
@@ -16,7 +16,7 @@ describe Rapns::Notification do
     notification.device_token = "a" * 64
     notification.alert = "way too long!" * 100
     notification.valid?.should be_false
-    notification.errors[:base].include?("APN notification cannot be larger than 256 bytes. Try condensing your alert and device attributes.").should be_true
+    notification.errors[:base].should include("APN notification payload cannot be larger than 256 bytes. Try condensing your alert attribute.")
   end
 
   it "should default the sound to 1.aiff" do


### PR DESCRIPTION
See

http://developer.apple.com/library/ios/#documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingWIthAPS/CommunicatingWIthAPS.html#//apple_ref/doc/uid/TP40008194-CH101-SW4

This would break support for Ruby 1.8.6 though, since String.bytesize is added in Ruby 1.8.7

And also there are utf8 mulit-byte issues which I will try to identify and fix, in that case life will be much easier if we stick to using String.bytesize

Can we just drop support for Ruby versions earlier than 1.8.7?
