### PR TITLE
Support for MDM messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 pkg/*
 coverage/
 .rbx/
+.idea/

--- a/lib/generators/rapns_generator.rb
+++ b/lib/generators/rapns_generator.rb
@@ -13,6 +13,7 @@ class RapnsGenerator < Rails::Generators::Base
     add_rapns_migration('create_rapns_notifications')
     add_rapns_migration('create_rapns_feedback')
     add_rapns_migration('add_alert_is_json_to_rapns_notifications')
+    add_rapns_migration('add_mdmsupport_to_rapns_notifications')
   end
 
   def copy_config

--- a/lib/generators/rapns_generator.rb
+++ b/lib/generators/rapns_generator.rb
@@ -14,6 +14,7 @@ class RapnsGenerator < Rails::Generators::Base
     add_rapns_migration('create_rapns_feedback')
     add_rapns_migration('add_alert_is_json_to_rapns_notifications')
     add_rapns_migration('add_mdmsupport_to_rapns_notifications')
+    add_rapns_migration('add_certname_to_rapns_notifications')
   end
 
   def copy_config

--- a/lib/generators/templates/add_certname_to_rapns_notifications.rb
+++ b/lib/generators/templates/add_certname_to_rapns_notifications.rb
@@ -1,0 +1,9 @@
+class AddCertnameToRapnsNotifications < ActiveRecord::Migration
+  def self.up
+    add_column :rapns_notifications, :cert_common, :string, :default => "default"
+  end
+
+  def self.down
+    remove_column :rapns_notifications, :cert_common
+  end
+end

--- a/lib/generators/templates/add_mdmsupport_to_rapns_notifications.rb
+++ b/lib/generators/templates/add_mdmsupport_to_rapns_notifications.rb
@@ -1,0 +1,9 @@
+class AddMdmsupportToRapnsNotifications < ActiveRecord::Migration
+  def self.up
+    add_column :rapns_notifications, :mdm, :string, :null => true
+  end
+
+  def self.down
+    remove_column :rapns_notifications, :mdm
+  end
+end

--- a/lib/generators/templates/rapns.yml
+++ b/lib/generators/templates/rapns.yml
@@ -1,6 +1,9 @@
 development:
   certificate: development.pem
   certificate_password:
+  # This value allows you to use other certificates which are stored in the database. The value of this parameter
+  # is a method name which will be called to evaluate the certificate. It has to return a string of
+  # certificate_callback: Tenant.evaluate_apn_certificate
 
   push:
     host: gateway.sandbox.push.apple.com
@@ -16,6 +19,8 @@ development:
 production:
   certificate: production.pem
   certificate_password:
+  # this value allows you to use other certificates which are stored in the database
+  # certificate_callback: Tenant.evaluate_apn_certificate
   airbrake_notify: true
   pid_file: tmp/pids/rapns.pid
 

--- a/lib/rapns/daemon/certificate.rb
+++ b/lib/rapns/daemon/certificate.rb
@@ -5,8 +5,13 @@ module Rapns
     class Certificate
       attr_accessor :certificate
 
-      def initialize(certificate_path)
-        @certificate_path = certificate_path
+      def initialize(certificate_path, options = {})
+        if options.has_key?(:data) && options[:data] == true
+          @certificate = certificate_path
+          @certificate_path = nil
+        else
+          @certificate_path = certificate_path
+        end
       end
 
       def load

--- a/lib/rapns/daemon/configuration.rb
+++ b/lib/rapns/daemon/configuration.rb
@@ -6,7 +6,7 @@ module Rapns
   module Daemon
     class Configuration
       attr_accessor :push, :feedback
-      attr_accessor :certificate, :certificate_password, :airbrake_notify, :pid_file
+      attr_accessor :certificate, :certificate_password, :certificate_callback, :airbrake_notify, :pid_file
       alias_method  :airbrake_notify?, :airbrake_notify
 
       def initialize(environment, config_path)
@@ -31,6 +31,7 @@ module Rapns
         set_variable(:feedback, :poll, config, :optional => true, :default => 60)
 
         set_variable(nil, :certificate, config)
+        set_variable(nil, :certificate_callback, config)
         set_variable(nil, :airbrake_notify, config, :optional => true, :default => true)
         set_variable(nil, :certificate_password, config, :optional => true, :default => "")
         set_variable(nil, :pid_file, config, :optional => true, :default => "")

--- a/lib/rapns/daemon/connection.rb
+++ b/lib/rapns/daemon/connection.rb
@@ -9,10 +9,16 @@ module Rapns
         30.minutes
       end
 
-      def initialize(name, host, port)
+      def initialize(name, host, port, options = {})
         @name = name
         @host = host
         @port = port
+        if options.has_key?(:certificate) && options[:certificate]
+          @certificate = options[:certificate]
+        else
+          @certificate = nil
+        end
+
         written
       end
 
@@ -88,9 +94,15 @@ module Rapns
       end
 
       def setup_ssl_context
+        if @certificate
+          certificate = @certificate.certificate
+        else
+          certificate = Rapns::Daemon.certificate.certificate
+        end
+
         ssl_context = OpenSSL::SSL::SSLContext.new
-        ssl_context.key = OpenSSL::PKey::RSA.new(Rapns::Daemon.certificate.certificate, Rapns::Daemon.configuration.certificate_password)
-        ssl_context.cert = OpenSSL::X509::Certificate.new(Rapns::Daemon.certificate.certificate)
+        ssl_context.key = OpenSSL::PKey::RSA.new(certificate, Rapns::Daemon.configuration.certificate_password)
+        ssl_context.cert = OpenSSL::X509::Certificate.new(certificate)
         ssl_context
       end
 

--- a/lib/rapns/daemon/delivery_handler.rb
+++ b/lib/rapns/daemon/delivery_handler.rb
@@ -24,11 +24,16 @@ module Rapns
         @name = "DeliveryHandler #{i}"
         host = Rapns::Daemon.configuration.push.host
         port = Rapns::Daemon.configuration.push.port
-        @connection = Connection.new(@name, host, port)
+        @connections = Hash.new
+        create_connection("default", nil)
       end
 
       def start
-        @connection.connect
+        # get the default connection
+        defaultConnection = @connections["default"]
+
+        # connect to
+        defaultConnection.connect
 
         Thread.new do
           loop do
@@ -45,10 +50,10 @@ module Rapns
 
       protected
 
-      def deliver(notification)
+      def deliver(notification, connection)
         begin
-          @connection.write(notification.to_binary)
-          check_for_error
+          connection.write(notification.to_binary)
+          check_for_error(connection)
 
           with_database_reconnect_and_retry do
             notification.delivered = true
@@ -69,17 +74,20 @@ module Rapns
           notification.delivered_at = nil
           notification.failed = true
           notification.failed_at = Time.now
-          notification.error_code = error.code
-          notification.error_description = error.description
+          begin
+            notification.error_code = error.code
+            notification.error_description = error.description
+          rescue
+          end
           notification.save!(:validate => false)
         end
       end
 
-      def check_for_error
-        if @connection.select(SELECT_TIMEOUT)
+      def check_for_error(connection)
+        if connection.select(SELECT_TIMEOUT)
           error = nil
 
-          if tuple = @connection.read(ERROR_TUPLE_BYTES)
+          if tuple = connection.read(ERROR_TUPLE_BYTES)
             cmd, code, notification_id = tuple.unpack("ccN")
 
             description = APN_ERRORS[code.to_i] || "Unknown error. Possible rapns bug?"
@@ -90,10 +98,61 @@ module Rapns
 
           begin
             Rapns::Daemon.logger.error("[#{@name}] Error received, reconnecting...")
-            @connection.reconnect
+            connection.reconnect
           ensure
             raise error if error
           end
+        end
+      end
+
+      def create_connection(conn_type, notification)
+        # check if we need to get the certificate from the database
+        certificate = nil
+        if !conn_type.eql?("default")
+
+          # get the evaluate callback
+          certCallbackName = Rapns::Daemon.configuration.certificate_callback
+
+          # send a message to them
+          begin
+            certificatePEM = eval("#{certCallbackName}(\"#{conn_type}\")")
+          rescue NoMethodError
+            Rapns::Daemon.logger.error("[#{@name}] Invalid method name for certificate evaluation...")
+            raise
+          rescue Exception => error
+            Rapns::Daemon.logger.error("[#{@name}] The evaluation method returned an error, setting this notification as failed...")
+            handle_delivery_error(notification, error)
+            raise
+          end
+
+
+          Rapns::Daemon.logger.info("[#{@name}] Received valid SSL certificate from the database...") if certificatePEM
+          certificate = Certificate.new(certificatePEM, :data => true)
+        end
+
+        host = Rapns::Daemon.configuration.push.host
+        port = Rapns::Daemon.configuration.push.port
+        connection = Connection.new("#{@name}_#{conn_type}", host, port, :certificate => certificate)
+        @connections[conn_type]=connection
+
+        # emit
+        return connection
+      end
+
+      def reuse_or_open_connection(conn_type, notification)
+        if @connections.has_key?(conn_type)
+          connection = @connections[conn_type]
+        else
+          connection = create_connection(conn_type, notification)
+          connection.connect
+        end
+
+        return connection
+      end
+
+      def close_connections()
+        @connections.eache do |c|
+          c.close
         end
       end
 
@@ -101,12 +160,13 @@ module Rapns
         notification = Rapns::Daemon.delivery_queue.pop
 
         if notification == STOP
-          @connection.close
+          close_connections
           return
         end
 
         begin
-          deliver(notification)
+          connection = reuse_or_open_connection(notification.cert_common, notification)
+          deliver(notification, connection)
         rescue StandardError => e
           Rapns::Daemon.logger.error(e)
         ensure

--- a/lib/rapns/notification.rb
+++ b/lib/rapns/notification.rb
@@ -50,11 +50,17 @@ module Rapns
 
     def as_json
       json = ActiveSupport::OrderedHash.new
-      json['aps'] = ActiveSupport::OrderedHash.new
-      json['aps']['alert'] = alert if alert
-      json['aps']['badge'] = badge if badge
-      json['aps']['sound'] = sound if sound
-      attributes_for_device.each { |k, v| json[k.to_s] = v.to_s } if attributes_for_device
+
+      if (mdm.nil?)
+        json['aps'] = ActiveSupport::OrderedHash.new
+        json['aps']['alert'] = alert if alert
+        json['aps']['badge'] = badge if badge
+        json['aps']['sound'] = sound if sound
+        attributes_for_device.each { |k, v| json[k.to_s] = v.to_s } if attributes_for_device
+      else
+        json['mdm'] = mdm
+      end
+
       json
     end
 


### PR DESCRIPTION
Apple supports a new notification message payload for MobileDeviceManagement solutions. As specified no other key is allowed in the hash when sending mdm messaged. This pull requests extends rapns for support of mdm messages!
