### PR TITLE
Fixed packing of the array to allow the 256 byte length in big endian

### DIFF
--- a/lib/rapns/notification.rb
+++ b/lib/rapns/notification.rb
@@ -81,7 +81,7 @@ module Rapns
     # http://developer.apple.com/library/ios/#documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingWIthAPS/CommunicatingWIthAPS.html#//apple_ref/doc/uid/TP40008194-CH101-SW4
     def to_binary(options = {})
       id_for_pack = options[:for_validation] ? 0 : id
-      [1, id_for_pack, expiry, 0, 32, device_token, 0, payload_size, payload].pack("cNNccH*cca*")
+      [1, id_for_pack, expiry, 0, 32, device_token, payload_size, payload].pack("cNNccH*na*")
     end
   end
 end


### PR DESCRIPTION
If a notification is sent with payload_size == 256, the delivery fails with error_code: 4 and error_description: 'Missing payload'.

The [documentation](http://developer.apple.com/library/ios/#documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingWIthAPS/CommunicatingWIthAPS.html#//apple_ref/doc/uid/TP40008194-CH101-SW1) says: 'The payload must not exceed 256 bytes and must not be null-terminated.' There is a problem with the the `pack` method in `notification.rb`. The documentation states 2 bytes for the payload length, the pack method uses the `c` value for the payload_size which is a 8-bit signed integer. So I removed the `1` and `c`. The other `c` is replaced the `a` n which is: Integer, 16-bit unsigned, network (big-endian) byte order.
