### PR TITLE
Replace Hash#to_json and ActiveSupport::JSON to MultiJson

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'mysql2'
 gem 'mysql'
 gem 'database_cleaner'
 gem 'simplecov'
+gem 'multi_json'
 #gem 'perftools.rb'
 
 gemspec

--- a/lib/rapns.rb
+++ b/lib/rapns.rb
@@ -1,4 +1,5 @@
 require 'active_record'
+require 'multi_json'
 
 require 'rapns/version'
 require 'rapns/binary_notification_validator'

--- a/lib/rapns/notification.rb
+++ b/lib/rapns/notification.rb
@@ -17,7 +17,7 @@ module Rapns
 
     def alert=(alert)
       if alert.is_a?(Hash)
-        write_attribute(:alert, ActiveSupport::JSON.encode(alert))
+        write_attribute(:alert, MultiJson.dump(alert))
         self.alert_is_json = true if has_attribute?(:alert_is_json)
       else
         write_attribute(:alert, alert)
@@ -30,22 +30,22 @@ module Rapns
 
       if has_attribute?(:alert_is_json)
         if alert_is_json?
-          ActiveSupport::JSON.decode(string_or_json)
+          MultiJson.load(string_or_json)
         else
           string_or_json
         end
       else
-        ActiveSupport::JSON.decode(string_or_json) rescue string_or_json
+        MultiJson.load(string_or_json) rescue string_or_json
       end
     end
 
     def attributes_for_device=(attrs)
       raise ArgumentError, "attributes_for_device must be a Hash" if !attrs.is_a?(Hash)
-      write_attribute(:attributes_for_device, ActiveSupport::JSON.encode(attrs))
+      write_attribute(:attributes_for_device, MultiJson.dump(attrs))
     end
 
     def attributes_for_device
-      ActiveSupport::JSON.decode(read_attribute(:attributes_for_device)) if read_attribute(:attributes_for_device)
+      MultiJson.load(read_attribute(:attributes_for_device)) if read_attribute(:attributes_for_device)
     end
 
     MDM_OVERIDE_KEY = '__rapns_mdm__'
@@ -70,7 +70,7 @@ module Rapns
     end
 
     def payload
-      as_json.to_json
+      MultiJson.dump(as_json)
     end
 
     def payload_size

--- a/rapns.gemspec
+++ b/rapns.gemspec
@@ -15,4 +15,6 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+
+  s.add_dependency "multi_json", "~> 1.0"
 end


### PR DESCRIPTION
To be able to select more fast and more space-saving JSON engine.

Space-saving is important for non-ascii utf8 string.
See the following examples.
- ActiveSupport::JSON
  ActiveSupport::JSON.encode( { "aps" => { "alert" => "あいうえお" } } ) #=> {"aps":{"alert":"\u3042\u3044\u3046\u3048\u304a"}} # 50 bytes
- MultiJSON with oj engine
  MultiJson.dump( { "aps" => { "alert" => "あいうえお" } ) #=>  {"aps":{"alert":"あいうえお"}} # 35 bytes
