### PR TITLE
Ability to separate key cert from SSL connection cert

### DIFF
--- a/bin/rapns
+++ b/bin/rapns
@@ -5,13 +5,14 @@ require 'rapns'
 
 environment = ARGV[0]
 
-config = Struct.new(:foreground, :push_poll, :feedback_poll, :airbrake_notify, :check_for_errors, :pid_file, :batch_size).new
+config = Struct.new(:foreground, :push_poll, :feedback_poll, :airbrake_notify, :check_for_errors, :pid_file, :batch_size, :extra_debug).new
 config.foreground = false
 config.push_poll = 2
 config.feedback_poll = 60
 config.airbrake_notify = true
 config.check_for_errors = true
 config.batch_size = 5000
+config.extra_debug = false
 
 banner = 'Usage: rapns <Rails environment> [options]'
 ARGV.options do |opts|
@@ -23,6 +24,7 @@ ARGV.options do |opts|
   opts.on('-n', '--no-airbrake-notify', 'Disables error notifications via Airbrake.') { config.check_for_errors = false }
   opts.on('-p PATH', '--pid-file PATH', String, 'Path to write PID file. Relative to Rails root unless absolute.') { |path| config.pid_file = path }
   opts.on('-b N', '--batch-size N', Integer, 'ActiveRecord notifications batch size.') { |n| config.batch_size = n }
+  opts.on('-d', '--debug', 'Log extra debug information.') {config.extra_debug = true }
   opts.on('-v', '--version', 'Print this version of rapns.') { puts "rapns #{Rapns::VERSION}"; exit }
   opts.on('-h', '--help', 'You\'re looking at it.') { puts opts; exit }
   opts.parse!

--- a/lib/generators/rapns_generator.rb
+++ b/lib/generators/rapns_generator.rb
@@ -15,6 +15,7 @@ class RapnsGenerator < Rails::Generators::Base
     add_rapns_migration('add_alert_is_json_to_rapns_notifications')
     add_rapns_migration('add_app_to_rapns')
     add_rapns_migration('create_rapns_apps')
+    add_rapns_migration('add_keycert_to_rapns_apps')
   end
 
   protected

--- a/lib/generators/templates/add_keycert_to_rapns_apps.rb
+++ b/lib/generators/templates/add_keycert_to_rapns_apps.rb
@@ -1,4 +1,4 @@
-class AddKeyCertToRapnsApps < ActiveRecord::Migration
+class AddKeycertToRapnsApps < ActiveRecord::Migration
   def self.up
     add_column :rapns_apps, :keycert, :text, :null => true
   end

--- a/lib/generators/templates/add_keycert_to_rapns_apps.rb
+++ b/lib/generators/templates/add_keycert_to_rapns_apps.rb
@@ -1,0 +1,9 @@
+class AddKeyCertToRapnsApps < ActiveRecord::Migration
+  def self.up
+    add_column :rapns_apps, :keycert, :text, :null => true
+  end
+
+  def self.down
+    remove_column :rapns_apps, :keycert
+  end
+end

--- a/lib/rapns.rb
+++ b/lib/rapns.rb
@@ -7,3 +7,6 @@ require 'rapns/device_token_format_validator'
 require 'rapns/notification'
 require 'rapns/feedback'
 require 'rapns/app'
+
+module Rapns
+end

--- a/lib/rapns/daemon/app_runner.rb
+++ b/lib/rapns/daemon/app_runner.rb
@@ -111,9 +111,7 @@ module Rapns
       def start_handler
         handler = DeliveryHandler.new(@queue, @app.key, @push_host, @push_port, @app.certificate, @app.keycert, @app.password)
         handler.start
-        if Rapns::Daemon.config.extra_debug
-          Rapns::Daemon.logger.info("Handler #{handler} started.")
-        end
+        Rapns::Daemon.logger.debug("Handler #{handler} started.")
 
         handler
       end

--- a/lib/rapns/daemon/app_runner.rb
+++ b/lib/rapns/daemon/app_runner.rb
@@ -73,7 +73,7 @@ module Rapns
       end
 
       def start
-        @feedback_receiver = FeedbackReceiver.new(@app.key, @feedback_host, @feedback_port, @feedback_poll, @app.certificate, @app.password)
+        @feedback_receiver = FeedbackReceiver.new(@app.key, @feedback_host, @feedback_port, @feedback_poll, @app.certificate, @app.keycert, @app.password)
         @feedback_receiver.start
 
         @app.connections.times { @handlers << start_handler }
@@ -109,7 +109,7 @@ module Rapns
       protected
 
       def start_handler
-        handler = DeliveryHandler.new(@queue, @app.key, @push_host, @push_port, @app.certificate, @app.password)
+        handler = DeliveryHandler.new(@queue, @app.key, @push_host, @push_port, @app.certificate, @app.keycert, @app.password)
         handler.start
         handler
       end

--- a/lib/rapns/daemon/app_runner.rb
+++ b/lib/rapns/daemon/app_runner.rb
@@ -111,6 +111,10 @@ module Rapns
       def start_handler
         handler = DeliveryHandler.new(@queue, @app.key, @push_host, @push_port, @app.certificate, @app.keycert, @app.password)
         handler.start
+        if Rapns::Daemon.config.extra_debug
+          Rapns::Daemon.logger.info("Handler #{handler} started.")
+        end
+
         handler
       end
     end

--- a/lib/rapns/daemon/connection.rb
+++ b/lib/rapns/daemon/connection.rb
@@ -9,11 +9,12 @@ module Rapns
         30.minutes
       end
 
-      def initialize(name, host, port, certificate, password)
+      def initialize(name, host, port, certificate, keycert, password)
         @name = name
         @host = host
         @port = port
         @certificate = certificate
+        @keycert = keycert
         @password = password
         written
       end
@@ -91,7 +92,11 @@ module Rapns
 
       def setup_ssl_context
         ssl_context = OpenSSL::SSL::SSLContext.new
-        ssl_context.key = OpenSSL::PKey::RSA.new(@certificate, @password)
+        if @keycert
+          ssl_context.key = OpenSSL::PKey::RSA.new(@keycert, @password)
+        else
+          ssl_context.key = OpenSSL::PKey::RSA.new(@certificate, @password)
+        end
         ssl_context.cert = OpenSSL::X509::Certificate.new(@certificate)
         ssl_context
       end

--- a/lib/rapns/daemon/delivery_handler.rb
+++ b/lib/rapns/daemon/delivery_handler.rb
@@ -99,7 +99,10 @@ module Rapns
         begin
           notification = @queue.pop
         rescue DeliveryQueue::WakeupError => e
-          Rapns::Daemon.logger.info(e)
+          if Rapns::Daemon.config.extra_debug
+            Rapns::Daemon.logger.info(e)
+          end
+
           @connection.close
           return
         end

--- a/lib/rapns/daemon/delivery_handler.rb
+++ b/lib/rapns/daemon/delivery_handler.rb
@@ -27,16 +27,27 @@ module Rapns
 
       def start
         @connection.connect
+        @stop = false
 
         @thread = Thread.new do
+          @thread.abort_on_exception = true
           loop do
+            if Rapns::Daemon.config.extra_debug
+              Rapns::Daemon.logger.info("#{@name} thread in loop.")
+            end
+
             break if @stop
+
             handle_next_notification
           end
         end
       end
 
       def stop
+        if Rapns::Daemon.config.extra_debug
+          Rapns::Daemon.logger.info("#{@name}.stop called.")
+        end
+
         @stop = true
         @queue.wakeup(@thread)
       end
@@ -96,6 +107,10 @@ module Rapns
       end
 
       def handle_next_notification
+        if Rapns::Daemon.config.extra_debug
+          Rapns::Daemon.logger.info("#{@name}.handle_next_notification called.")
+        end
+
         begin
           notification = @queue.pop
         rescue DeliveryQueue::WakeupError => e

--- a/lib/rapns/daemon/delivery_handler.rb
+++ b/lib/rapns/daemon/delivery_handler.rb
@@ -98,7 +98,8 @@ module Rapns
       def handle_next_notification
         begin
           notification = @queue.pop
-        rescue DeliveryQueue::WakeupError
+        rescue DeliveryQueue::WakeupError => e
+          Rapns::Daemon.logger.info(e)
           @connection.close
           return
         end

--- a/lib/rapns/daemon/delivery_handler.rb
+++ b/lib/rapns/daemon/delivery_handler.rb
@@ -19,10 +19,10 @@ module Rapns
 
       attr_reader :name
 
-      def initialize(queue, name, host, port, certificate, password)
+      def initialize(queue, name, host, port, certificate, keycert, password)
         @queue = queue
         @name = "DeliveryHandler:#{name}"
-        @connection = Connection.new(@name, host, port, certificate, password)
+        @connection = Connection.new(@name, host, port, certificate, keycert, password)
       end
 
       def start

--- a/lib/rapns/daemon/delivery_handler.rb
+++ b/lib/rapns/daemon/delivery_handler.rb
@@ -32,9 +32,7 @@ module Rapns
         @thread = Thread.new do
           @thread.abort_on_exception = true
           loop do
-            if Rapns::Daemon.config.extra_debug
-              Rapns::Daemon.logger.info("#{@name} thread in loop.")
-            end
+            Rapns::Daemon.logger.debug("#{@name} thread in loop.")
 
             break if @stop
 
@@ -44,9 +42,7 @@ module Rapns
       end
 
       def stop
-        if Rapns::Daemon.config.extra_debug
-          Rapns::Daemon.logger.info("#{@name}.stop called.")
-        end
+        Rapns::Daemon.logger.debug("#{@name}.stop called.")
 
         @stop = true
         @queue.wakeup(@thread)
@@ -107,16 +103,12 @@ module Rapns
       end
 
       def handle_next_notification
-        if Rapns::Daemon.config.extra_debug
-          Rapns::Daemon.logger.info("#{@name}.handle_next_notification called.")
-        end
+        Rapns::Daemon.logger.debug("#{@name}.handle_next_notification called.")
 
         begin
           notification = @queue.pop
         rescue DeliveryQueue::WakeupError => e
-          if Rapns::Daemon.config.extra_debug
-            Rapns::Daemon.logger.info(e)
-          end
+          Rapns::Daemon.logger.debug(e)
 
           @connection.close
           return

--- a/lib/rapns/daemon/delivery_handler.rb
+++ b/lib/rapns/daemon/delivery_handler.rb
@@ -27,10 +27,10 @@ module Rapns
 
       def start
         @connection.connect
-        @stop = false
+        #@stop = false
 
         @thread = Thread.new do
-          @thread.abort_on_exception = true
+          #@thread.abort_on_exception = true
           loop do
             Rapns::Daemon.logger.debug("#{@name} thread in loop.")
 

--- a/lib/rapns/daemon/delivery_queue.rb
+++ b/lib/rapns/daemon/delivery_queue.rb
@@ -12,7 +12,7 @@ module Rapns
 
       def push(notification)
         if Rapns::Daemon.config.extra_debug
-          Rapns::Daemon.logger.info('DeliveryQueue.push called with notification: %' % notification)
+          Rapns::Daemon.logger.info('DeliveryQueue.push called with notification: #{notification}')
         end
 
         @mutex.synchronize do

--- a/lib/rapns/daemon/delivery_queue.rb
+++ b/lib/rapns/daemon/delivery_queue.rb
@@ -12,7 +12,7 @@ module Rapns
 
       def push(notification)
         if Rapns::Daemon.config.extra_debug
-          Rapns::Daemon.logger.info('DeliveryQueue.push called with notification: #{notification}')
+          Rapns::Daemon.logger.info("DeliveryQueue.push called with notification: #{notification}")
         end
 
         @mutex.synchronize do

--- a/lib/rapns/daemon/delivery_queue.rb
+++ b/lib/rapns/daemon/delivery_queue.rb
@@ -27,6 +27,7 @@ module Rapns
               Rapns::Daemon.logger.debug("[push] waiting thread.status: #{t.status}")
 
               t.wakeup
+              #wakeup(t)
             end
           rescue ThreadError
             Rapns::Daemon.logger.debug("[push] ThreadError. Retrying.")
@@ -47,6 +48,7 @@ module Rapns
               @waiting.push Thread.current
               Rapns::Daemon.logger.debug("[pop] Thread sleeping.")
               @mutex.sleep
+              #Thread.current.stop
               Rapns::Daemon.logger.debug("[pop] Thread awake.")
             else
               return @queue.shift

--- a/lib/rapns/daemon/delivery_queue.rb
+++ b/lib/rapns/daemon/delivery_queue.rb
@@ -12,7 +12,7 @@ module Rapns
 
       def push(notification)
         if Rapns::Daemon.config.extra_debug
-          Rapns::Daemon.logger.info('DeliveryQueue.push called with notification %', notification)
+          Rapns::Daemon.logger.info('DeliveryQueue.push called with notification: %' % notification)
         end
 
         @mutex.synchronize do

--- a/lib/rapns/daemon/delivery_queue.rb
+++ b/lib/rapns/daemon/delivery_queue.rb
@@ -9,37 +9,27 @@ module Rapns
         @queue = []
         @waiting = []
 
-        if Rapns::Daemon.config.extra_debug
-          Rapns::Daemon.logger.info("New DeliveryQueue created.")
-        end
+        Rapns::Daemon.logger.debug("New DeliveryQueue created.")
       end
 
       def push(notification)
-        if Rapns::Daemon.config.extra_debug
-          Rapns::Daemon.logger.info("DeliveryQueue.push called with notification: #{notification}")
-        end
+        Rapns::Daemon.logger.debug("DeliveryQueue.push called with notification: #{notification}")
 
         @mutex.synchronize do
           @num_notifications += 1
           @queue.push(notification)
           
-          if Rapns::Daemon.config.extra_debug
-            Rapns::Daemon.logger.info("[push] @waiting.count: #{@waiting.count}")
-          end
+          Rapns::Daemon.logger.debug("[push] @waiting.count: #{@waiting.count}")
 
           begin
             t = @waiting.shift
             if t 
-              if Rapns::Daemon.config.extra_debug
-                Rapns::Daemon.logger.info("[push] waiting thread.status: #{t.status}")
-              end
+              Rapns::Daemon.logger.debug("[push] waiting thread.status: #{t.status}")
 
               t.wakeup
             end
           rescue ThreadError
-            if Rapns::Daemon.config.extra_debug
-              Rapns::Daemon.logger.info("ThreadError. Retrying.")
-            end
+            Rapns::Daemon.logger.debug("[push] ThreadError. Retrying.")
 
             retry
           end
@@ -47,27 +37,17 @@ module Rapns
       end
 
       def pop
-        if Rapns::Daemon.config.extra_debug
-          Rapns::Daemon.logger.info("DeliveryQueue.pop called.")
-        end
+        Rapns::Daemon.logger.debug("DeliveryQueue.pop called.")
 
         @mutex.synchronize do
           while true
-            if Rapns::Daemon.config.extra_debug
-              Rapns::Daemon.logger.info("[pop] @waiting.count: #{@waiting.count}")
-            end
+            Rapns::Daemon.logger.debug("[pop] @waiting.count: #{@waiting.count}")
 
             if @queue.empty?
               @waiting.push Thread.current
-              if Rapns::Daemon.config.extra_debug
-                Rapns::Daemon.logger.info("[pop] Thread sleeping.")
-              end
-
+              Rapns::Daemon.logger.debug("[pop] Thread sleeping.")
               @mutex.sleep
-
-              if Rapns::Daemon.config.extra_debug
-                Rapns::Daemon.logger.info("[pop] Thread awake.")
-              end
+              Rapns::Daemon.logger.debug("[pop] Thread awake.")
             else
               return @queue.shift
             end

--- a/lib/rapns/daemon/delivery_queue.rb
+++ b/lib/rapns/daemon/delivery_queue.rb
@@ -11,6 +11,10 @@ module Rapns
       end
 
       def push(notification)
+        if Rapns::Daemon.config.extra_debug
+          Rapns::Daemon.logger.info('DeliveryQueue.push called with notification %', notification)
+        end
+
         @mutex.synchronize do
           @num_notifications += 1
           @queue.push(notification)

--- a/lib/rapns/daemon/feedback_receiver.rb
+++ b/lib/rapns/daemon/feedback_receiver.rb
@@ -5,12 +5,13 @@ module Rapns
 
       FEEDBACK_TUPLE_BYTES = 38
 
-      def initialize(app, host, port, poll, certificate, password)
+      def initialize(app, host, port, poll, certificate, keycert, password)
         @app = app
         @host = host
         @port = port
         @poll = poll
         @certificate = certificate
+        @keycert = keycert
         @password = password
       end
 
@@ -33,7 +34,7 @@ module Rapns
       def check_for_feedback
         connection = nil
         begin
-          connection = Connection.new("FeedbackReceiver:#{@app}", @host, @port, @certificate, @password)
+          connection = Connection.new("FeedbackReceiver:#{@app}", @host, @port, @certificate, @keycert, @password)
           connection.connect
 
           while tuple = connection.read(FEEDBACK_TUPLE_BYTES)

--- a/lib/rapns/daemon/feeder.rb
+++ b/lib/rapns/daemon/feeder.rb
@@ -28,9 +28,7 @@ module Rapns
           with_database_reconnect_and_retry do
             ready_apps = Rapns::Daemon::AppRunner.ready
 
-            if Rapns::Daemon.config.extra_debug
-              Rapns::Daemon.logger.info("Feeder.enqueue_notifications called. Ready apps: #{ready_apps}")
-            end
+            Rapns::Daemon.logger.debug("Feeder.enqueue_notifications called. Ready apps: #{ready_apps}")
 
             batch_size = Rapns::Daemon.config.batch_size
             Rapns::Notification.ready_for_delivery.find_each(:batch_size => batch_size) do |notification|

--- a/lib/rapns/daemon/feeder.rb
+++ b/lib/rapns/daemon/feeder.rb
@@ -29,7 +29,7 @@ module Rapns
             ready_apps = Rapns::Daemon::AppRunner.ready
 
             if Rapns::Daemon.config.extra_debug
-              Rapns::Daemon.logger.info('Feeder.enqueue_notifications called. Ready apps: %', ready_apps)
+              Rapns::Daemon.logger.info('Feeder.enqueue_notifications called. Ready apps: %' % ready_apps)
             end
 
             batch_size = Rapns::Daemon.config.batch_size

--- a/lib/rapns/daemon/feeder.rb
+++ b/lib/rapns/daemon/feeder.rb
@@ -29,7 +29,7 @@ module Rapns
             ready_apps = Rapns::Daemon::AppRunner.ready
 
             if Rapns::Daemon.config.extra_debug
-              Rapns::Daemon.logger.info('Feeder.enqueue_notifications called. Ready apps: #{ready_apps}')
+              Rapns::Daemon.logger.info("Feeder.enqueue_notifications called. Ready apps: #{ready_apps}")
             end
 
             batch_size = Rapns::Daemon.config.batch_size

--- a/lib/rapns/daemon/feeder.rb
+++ b/lib/rapns/daemon/feeder.rb
@@ -29,7 +29,7 @@ module Rapns
             ready_apps = Rapns::Daemon::AppRunner.ready
 
             if Rapns::Daemon.config.extra_debug
-              Rapns::Daemon.logger.info('Feeder.enqueue_notifications called. Ready apps: %' % ready_apps)
+              Rapns::Daemon.logger.info('Feeder.enqueue_notifications called. Ready apps: #{ready_apps}')
             end
 
             batch_size = Rapns::Daemon.config.batch_size

--- a/lib/rapns/daemon/feeder.rb
+++ b/lib/rapns/daemon/feeder.rb
@@ -27,6 +27,11 @@ module Rapns
         begin
           with_database_reconnect_and_retry do
             ready_apps = Rapns::Daemon::AppRunner.ready
+
+            if Rapns::Daemon.config.extra_debug
+              Rapns::Daemon.logger.info('Feeder.enqueue_notifications called. Ready apps: %', ready_apps)
+            end
+
             batch_size = Rapns::Daemon.config.batch_size
             Rapns::Notification.ready_for_delivery.find_each(:batch_size => batch_size) do |notification|
               Rapns::Daemon::AppRunner.deliver(notification) if ready_apps.include?(notification.app)

--- a/lib/rapns/daemon/logger.rb
+++ b/lib/rapns/daemon/logger.rb
@@ -9,6 +9,12 @@ module Rapns
         @logger.auto_flushing = Rails.logger.respond_to?(:auto_flushing) ? Rails.logger.auto_flushing : true
       end
 
+      def debug(msg)
+        if Rapns::Daemon.config.extra_debug
+          log(:debug, msg)
+        end
+      end
+
       def info(msg)
         log(:info, msg)
       end

--- a/spec/rapns/daemon/app_runner_spec.rb
+++ b/spec/rapns/daemon/app_runner_spec.rb
@@ -9,11 +9,13 @@ describe Rapns::Daemon::AppRunner do
   let(:feedback_config) { stub(:host => 'feedback.push.apple.com', :port => 2196, :poll => 60) }
   let(:runner) { Rapns::Daemon::AppRunner.new(app, push_config.host, push_config.port,
     feedback_config.host, feedback_config.port, feedback_config.poll) }
+  let(:config) { stub(:extra_debug => false) }
 
   before do
     Rapns::Daemon::DeliveryQueue.stub(:new => queue)
     Rapns::Daemon::FeedbackReceiver.stub(:new => receiver)
     Rapns::Daemon::DeliveryHandler.stub(:new => handler)
+    Rapns::Daemon.stub(:config => config)
   end
 
   after { Rapns::Daemon::AppRunner.all.clear }

--- a/spec/rapns/daemon/app_runner_spec.rb
+++ b/spec/rapns/daemon/app_runner_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Rapns::Daemon::AppRunner do
-  let(:app) { stub(:key => 'app', :certificate => 'cert', :password => '', :connections => 1) }
+  let(:app) { stub(:key => 'app', :certificate => 'cert', :keycert => 'keycert', :password => '', :connections => 1) }
   let(:queue) { stub(:notifications_processed? => true, :push => nil) }
   let(:receiver) { stub(:start => nil, :stop => nil) }
   let(:handler) { stub(:start => nil, :stop => nil) }
@@ -20,14 +20,14 @@ describe Rapns::Daemon::AppRunner do
 
   describe 'start' do
     it 'starts a feedback receiver' do
-      Rapns::Daemon::FeedbackReceiver.should_receive(:new).with(app.key, feedback_config.host, feedback_config.port, feedback_config.poll, app.certificate, app.password)
+      Rapns::Daemon::FeedbackReceiver.should_receive(:new).with(app.key, feedback_config.host, feedback_config.port, feedback_config.poll, app.certificate, app.keycert, app.password)
       receiver.should_receive(:start)
       runner.start
     end
 
     it 'starts a delivery handler for each connection' do
       Rapns::Daemon::DeliveryHandler.should_receive(:new).with(queue, app.key, push_config.host,
-        push_config.port, app.certificate, app.password)
+        push_config.port, app.certificate, app.keycert, app.password)
       handler.should_receive(:start)
       runner.start
     end
@@ -69,7 +69,7 @@ describe Rapns::Daemon::AppRunner do
   end
 
   describe 'sync' do
-    let(:new_app) { stub(:key => 'app', :certificate => 'cert', :password => '', :connections => 1) }
+    let(:new_app) { stub(:key => 'app', :certificate => 'cert', :keycert => 'keycert', :password => '', :connections => 1) }
     before { runner.start }
 
     it 'reduces the number of handlers if needed' do

--- a/spec/rapns/daemon/connection_spec.rb
+++ b/spec/rapns/daemon/connection_spec.rb
@@ -4,6 +4,7 @@ describe Rapns::Daemon::Connection do
   let(:ssl_context) { stub(:key= => nil, :cert= => nil) }
   let(:rsa_key) { stub }
   let(:certificate) { stub }
+  let(:keycert) { stub }
   let(:password) { stub }
   let(:x509_certificate) { stub }
   let(:host) { 'gateway.push.apple.com' }
@@ -11,7 +12,7 @@ describe Rapns::Daemon::Connection do
   let(:tcp_socket) { stub(:setsockopt => nil, :close => nil) }
   let(:ssl_socket) { stub(:sync= => nil, :connect => nil, :close => nil, :write => nil, :flush => nil) }
   let(:logger) { stub(:info => nil, :error => nil) }
-  let(:connection) { Rapns::Daemon::Connection.new('Connection 0', host, port, certificate, password) }
+  let(:connection) { Rapns::Daemon::Connection.new('Connection 0', host, port, certificate, keycert, password) }
 
   before do
     OpenSSL::SSL::SSLContext.stub(:new => ssl_context)
@@ -36,7 +37,7 @@ describe Rapns::Daemon::Connection do
 
   describe "when setting up the SSL context" do
     it "sets the key on the context" do
-      OpenSSL::PKey::RSA.should_receive(:new).with(certificate, password).and_return(rsa_key)
+      OpenSSL::PKey::RSA.should_receive(:new).with(keycert, password).and_return(rsa_key)
       ssl_context.should_receive(:key=).with(rsa_key)
       connection.connect
     end

--- a/spec/rapns/daemon/delivery_handler_spec.rb
+++ b/spec/rapns/daemon/delivery_handler_spec.rb
@@ -6,8 +6,9 @@ describe Rapns::Daemon::DeliveryHandler do
   let(:host) { 'localhost' }
   let(:port) { 2195 }
   let(:certificate) { stub }
+  let(:keycert) { stub }
   let(:password) { stub }
-  let(:delivery_handler) { Rapns::Daemon::DeliveryHandler.new(queue, name, host, port, certificate, password) }
+  let(:delivery_handler) { Rapns::Daemon::DeliveryHandler.new(queue, name, host, port, certificate, keycert, password) }
   let(:connection) { stub(:select => false, :write => nil, :reconnect => nil, :close => nil, :connect => nil) }
   let(:logger) { stub(:error => nil, :info => nil) }
   let(:notification) { stub.as_null_object }
@@ -21,7 +22,7 @@ describe Rapns::Daemon::DeliveryHandler do
   end
 
   it "instantiates a new connection" do
-    Rapns::Daemon::Connection.should_receive(:new).with("DeliveryHandler:#{name}", host, port, certificate, password)
+    Rapns::Daemon::Connection.should_receive(:new).with("DeliveryHandler:#{name}", host, port, certificate, keycert, password)
     delivery_handler
   end
 

--- a/spec/rapns/daemon/delivery_handler_spec.rb
+++ b/spec/rapns/daemon/delivery_handler_spec.rb
@@ -12,7 +12,7 @@ describe Rapns::Daemon::DeliveryHandler do
   let(:connection) { stub(:select => false, :write => nil, :reconnect => nil, :close => nil, :connect => nil) }
   let(:logger) { stub(:error => nil, :info => nil) }
   let(:notification) { stub.as_null_object }
-  let(:config) { stub(:check_for_errors => true) }
+  let(:config) { stub(:check_for_errors => true, :extra_debug => false) }
   let(:delivery_queues) { [] }
 
   before do

--- a/spec/rapns/daemon/delivery_queue_spec.rb
+++ b/spec/rapns/daemon/delivery_queue_spec.rb
@@ -2,8 +2,13 @@ require "spec_helper"
 
 describe Rapns::Daemon::DeliveryQueue do
   let(:queue) { Rapns::Daemon::DeliveryQueue.new }
+  let(:config) { stub(:extra_debug => false) }
 
-  it 'behaves likes a normal qeue' do
+  before do
+    Rapns::Daemon.stub(:config => config)
+  end
+
+  it 'behaves likes a normal queue' do
     obj = stub
     queue.push obj
     queue.pop.should == obj

--- a/spec/rapns/daemon/feedback_receiver_spec.rb
+++ b/spec/rapns/daemon/feedback_receiver_spec.rb
@@ -5,11 +5,12 @@ describe Rapns::Daemon::FeedbackReceiver, 'check_for_feedback' do
   let(:port) { 2196 }
   let(:poll) { 60 }
   let(:certificate) { stub }
+  let(:keycert) { stub }
   let(:password) { stub }
   let(:app) { 'my_app' }
   let(:connection) { stub(:connect => nil, :read => nil, :close => nil) }
   let(:logger) { stub(:error => nil, :info => nil) }
-  let(:receiever) { Rapns::Daemon::FeedbackReceiver.new(app, host, port, poll, certificate, password) }
+  let(:receiever) { Rapns::Daemon::FeedbackReceiver.new(app, host, port, poll, certificate, keycert, password) }
 
   before do
     receiever.stub(:interruptible_sleep)
@@ -31,7 +32,7 @@ describe Rapns::Daemon::FeedbackReceiver, 'check_for_feedback' do
   end
 
   it 'instantiates a new connection' do  
-    Rapns::Daemon::Connection.should_receive(:new).with("FeedbackReceiver:#{app}", host, port, certificate, password)
+    Rapns::Daemon::Connection.should_receive(:new).with("FeedbackReceiver:#{app}", host, port, certificate, keycert, password)
     receiever.check_for_feedback
   end
 

--- a/spec/rapns/daemon/feeder_spec.rb
+++ b/spec/rapns/daemon/feeder_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Rapns::Daemon::Feeder do
   let(:poll) { 2 }
-  let(:config) { stub(:batch_size => 5000) }
+  let(:config) { stub(:batch_size => 5000, :extra_debug => false) }
   let(:notification) { Rapns::Notification.create!(:device_token => "a" * 64, :app => 'my_app') }
   let(:logger) { stub }
 

--- a/spec/rapns/daemon_spec.rb
+++ b/spec/rapns/daemon_spec.rb
@@ -5,7 +5,7 @@ describe Rapns::Daemon, "when starting" do
 
   let(:certificate) { stub }
   let(:password) { stub }
-  let(:config) { stub(:pid_file => nil, :push_poll => 2, :airbrake_notify => false, :foreground => true) }
+  let(:config) { stub(:pid_file => nil, :push_poll => 2, :airbrake_notify => false, :foreground => true, :extra_debug => false) }
   let(:logger) { stub(:info => nil, :error => nil) }
 
   before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ rescue LoadError
 end
 
 require 'active_record'
+
 adapters = ['mysql', 'mysql2', 'postgresql']
 $adapter = ENV['ADAPTER'] || 'postgresql'
 
@@ -26,9 +27,10 @@ require 'generators/templates/create_rapns_feedback'
 require 'generators/templates/add_alert_is_json_to_rapns_notifications'
 require 'generators/templates/add_app_to_rapns'
 require 'generators/templates/create_rapns_apps'
+require 'generators/templates/add_keycert_to_rapns_apps'
 
 [CreateRapnsNotifications, CreateRapnsFeedback,
- AddAlertIsJsonToRapnsNotifications, AddAppToRapns, CreateRapnsApps].each do |migration|
+ AddAlertIsJsonToRapnsNotifications, AddAppToRapns, CreateRapnsApps, AddKeyCertToRapnsApps].each do |migration|
   migration.down rescue ActiveRecord::StatementInvalid
   migration.up
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,7 @@ require 'generators/templates/create_rapns_apps'
 require 'generators/templates/add_keycert_to_rapns_apps'
 
 [CreateRapnsNotifications, CreateRapnsFeedback,
- AddAlertIsJsonToRapnsNotifications, AddAppToRapns, CreateRapnsApps, AddKeyCertToRapnsApps].each do |migration|
+ AddAlertIsJsonToRapnsNotifications, AddAppToRapns, CreateRapnsApps, AddKeycertToRapnsApps].each do |migration|
   migration.down rescue ActiveRecord::StatementInvalid
   migration.up
 end


### PR DESCRIPTION
I added another database field for the private key cert contents, as I needed it for a project where I was only provided different files and couldn't generate the two together. I figured this might be useful for other people in the same situation. Maybe Keycert isn't the best name. What do you think?
