### PR TITLE
Allow same app key in multi environments.

### DIFF
--- a/lib/rapns/app.rb
+++ b/lib/rapns/app.rb
@@ -4,7 +4,7 @@ module Rapns
 
     attr_accessible :key, :environment, :certificate, :password, :connections
 
-    validates :key, :presence => true, :uniqueness => true
+    validates :key, :presence => true, :uniqueness => { :scope => :environment }
     validates :environment, :presence => true, :inclusion => { :in => %w(development production) }
     validates :certificate, :presence => true
     validates_numericality_of :connections, :greater_than => 0, :only_integer => true


### PR DESCRIPTION
Allow below situations:

app = Rapns::App.new
app.key = "my_app"
app.certificate = File.read("/path/to/development.pem")
app.environment = "development"
app.password = "certificate password"
app.connections = 1
app.save!

app = Rapns::App.new
app.key = "my_app" # use same app key in production.
app.certificate = File.read("/path/to/production.pem")
app.environment = "production"
app.password = "certificate password"
app.connections = 1
app.save!
