### PR TITLE
Prevent failed connection from stopping the daemon - see Issue #62

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,4 @@ Thank you to the following wonderful people for contributing to rapns:
 * [@EpicDraws](https://github.com/EpicDraws)
 * [@dei79](https://github.com/dei79)
 * [@adorr](https://github.com/adorr)
+* [@mattconnolly](https://github.com/mattconnolly)

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,7 +4,7 @@ postgresql:
   adapter: postgresql
   database: rapns_test
   host: localhost
-  username: rapns_test
+  username: postgres
   password: ""
 
 jdbcpostgresql:

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,0 +1,31 @@
+# postgresql is the default if no ADAPTER environment variable is set when running specs.
+
+postgresql:
+  adapter: postgresql
+  database: postgres
+  host: localhost
+  username: rapns_test
+  password: ""
+
+jdbcpostgresql:
+  adapter: jdbcpostgresql
+  database: rapns_test
+  host: localhost
+  username: postgres
+  password: ""
+
+mysql:
+  adapter: mysql
+  database: rapns_test
+  host: localhost
+  username: rapns_test
+  password: ""
+  encoding: utf8
+
+mysql2:
+  adapter: mysql
+  database: rapns_test
+  host: localhost
+  username: rapns_test
+  password: ""
+  encoding: utf8

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,7 +2,7 @@
 
 postgresql:
   adapter: postgresql
-  database: postgres
+  database: rapns_test
   host: localhost
   username: rapns_test
   password: ""

--- a/lib/rapns/daemon/connection.rb
+++ b/lib/rapns/daemon/connection.rb
@@ -105,6 +105,9 @@ module Rapns
         ssl_socket.connect
         Rapns::Daemon.logger.info("[#{@name}] Connected to #{@host}:#{@port}")
         [tcp_socket, ssl_socket]
+      rescue StandardError => e
+        Rapns::Daemon.logger.error("[#{@name}] Error connecting to #{@host}:#{@port} : #{e}")
+        raise
       end
     end
   end

--- a/lib/rapns/daemon/feedback_receiver.rb
+++ b/lib/rapns/daemon/feedback_receiver.rb
@@ -5,8 +5,8 @@ module Rapns
 
       FEEDBACK_TUPLE_BYTES = 38
 
-      def initialize(app, host, port, poll, certificate, password)
-        @app = app
+      def initialize(name, host, port, poll, certificate, password)
+        @name = name
         @host = host
         @port = port
         @poll = poll
@@ -33,7 +33,7 @@ module Rapns
       def check_for_feedback
         connection = nil
         begin
-          connection = Connection.new("FeedbackReceiver:#{@app}", @host, @port, @certificate, @password)
+          connection = Connection.new("FeedbackReceiver:#{@name}", @host, @port, @certificate, @password)
           connection.connect
 
           while tuple = connection.read(FEEDBACK_TUPLE_BYTES)
@@ -56,8 +56,8 @@ module Rapns
 
       def create_feedback(failed_at, device_token)
         formatted_failed_at = failed_at.strftime("%Y-%m-%d %H:%M:%S UTC")
-        Rapns::Daemon.logger.info("[FeedbackReceiver:#{@app}] Delivery failed at #{formatted_failed_at} for #{device_token}")
-        Rapns::Feedback.create!(:failed_at => failed_at, :device_token => device_token, :app => @app)
+        Rapns::Daemon.logger.info("[FeedbackReceiver:#{@name}] Delivery failed at #{formatted_failed_at} for #{device_token}")
+        Rapns::Feedback.create!(:failed_at => failed_at, :device_token => device_token, :app => @name)
       end
     end
   end

--- a/lib/rapns/daemon/feedback_receiver.rb
+++ b/lib/rapns/daemon/feedback_receiver.rb
@@ -25,8 +25,8 @@ module Rapns
               # and retrying later might make sense (for example, a network outage)
               @stop = true
               break
-            rescue StandardError => e
-              Rapns::Daemon.logger.error e
+            rescue
+              # error will be logged in check_for_feedback
             end
             interruptible_sleep @poll
           end
@@ -49,6 +49,9 @@ module Rapns
             timestamp, device_token = parse_tuple(tuple)
             create_feedback(timestamp, device_token)
           end
+        rescue StandardError => e
+          Rapns::Daemon.logger.error(e)
+          raise
         ensure
           connection.close if connection
         end

--- a/rapns.gemspec
+++ b/rapns.gemspec
@@ -11,9 +11,9 @@ Gem::Specification.new do |s|
   s.summary     = %q{Easy to use, full featured APNs daemon for Rails 3}
   s.description = %q{Easy to use, full featured APNs daemon for Rails 3}
 
-  s.files         = `git ls-files lib`.split("\n") + ["README.md", "CHANGELOG.md", "LICENSE"]
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.files         = `git ls-files -- lib README.md CHANGELOG.md LICENSE`.split("\n")
+  s.test_files    = `git ls-files -- {test,spec,features,config}`.split("\n")
+  s.executables   = `git ls-files -- bin`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
   s.add_dependency "multi_json", "~> 1.0"

--- a/spec/rapns/daemon/connection_spec.rb
+++ b/spec/rapns/daemon/connection_spec.rb
@@ -110,7 +110,7 @@ describe Rapns::Daemon::Connection do
     it "ignores IOError when the socket is already closed" do
       tcp_socket.stub(:close).and_raise(IOError)
       connection.connect
-      expect { connection.close }.should_not raise_error(IOError)
+      expect { connection.close }.to_not raise_error(IOError)
     end
   end
 

--- a/spec/rapns/daemon/feedback_receiver_spec.rb
+++ b/spec/rapns/daemon/feedback_receiver_spec.rb
@@ -66,7 +66,7 @@ describe Rapns::Daemon::FeedbackReceiver, 'check_for_feedback' do
     error = StandardError.new('bork!')
     connection.stub(:read).and_raise(error)
     Rapns::Daemon.logger.should_receive(:error).with(error)
-    receiever.check_for_feedback
+    lambda { receiever.check_for_feedback }.should raise_error
   end
 
   it 'sleeps for the feedback poll period' do

--- a/spec/rapns/notification_spec.rb
+++ b/spec/rapns/notification_spec.rb
@@ -43,7 +43,7 @@ end
 
 describe Rapns::Notification, "when assigning the attributes for the device" do
   it "should raise an ArgumentError if something other than a Hash is assigned" do
-    expect { Rapns::Notification.new(:attributes_for_device => Array.new) }.should
+    expect { Rapns::Notification.new(:attributes_for_device => Array.new) }.to \
       raise_error(ArgumentError, "attributes_for_device must be a Hash")
   end
 


### PR DESCRIPTION
Prevent failed connection from stopping the daemon - see Issue #62.

There's a few other small adjustments in this pull request too:
- Updated deprecated rspec expects
- Moved database test configuration into a config file instead of hard coded.
- refactored a variable name to better reflect the content of the variable.
