### PR TITLE
Open a log file in append mode

### DIFF
--- a/lib/rapns/daemon/logger.rb
+++ b/lib/rapns/daemon/logger.rb
@@ -3,7 +3,7 @@ module Rapns
     class Logger
       def initialize(options)
         @options = options
-        log = File.open(File.join(Rails.root, 'log', 'rapns.log'), 'w')
+        log = File.open(File.join(Rails.root, 'log', 'rapns.log'), 'a')
         log.sync = true
         @logger = ActiveSupport::BufferedLogger.new(log, Rails.logger.level)
         @logger.auto_flushing = Rails.logger.respond_to?(:auto_flushing) ? Rails.logger.auto_flushing : true

--- a/spec/rapns/daemon/logger_spec.rb
+++ b/spec/rapns/daemon/logger_spec.rb
@@ -34,7 +34,7 @@ describe Rapns::Daemon::Logger do
   end
 
   it "should open the a log file in the Rails log directory" do
-    File.should_receive(:open).with('/rails_root/log/rapns.log', 'w')
+    File.should_receive(:open).with('/rails_root/log/rapns.log', 'a')
     Rapns::Daemon::Logger.new(:foreground => true)
   end
 


### PR DESCRIPTION
Now, a rapns log file is opened in write mode. So, when a rapns daemon restarted, a rapns log file cleaned up.

I wish remaining before restating logs. 
