### PR TITLE
Reset sound default to "default"

### DIFF
--- a/lib/generators/templates/add_gcm.rb
+++ b/lib/generators/templates/add_gcm.rb
@@ -25,6 +25,7 @@ class AddGcm < ActiveRecord::Migration
     change_column_null :rapns_apps, :certificate, true
 
     change_column :rapns_notifications, :error_description, :text
+    change_column :rapns_notifications, :sound, :string, :default => 'default'
 
     rename_column :rapns_notifications, :attributes_for_device, :data
     rename_column :rapns_apps, :key, :name

--- a/lib/generators/templates/create_rapns_notifications.rb
+++ b/lib/generators/templates/create_rapns_notifications.rb
@@ -3,7 +3,7 @@ class CreateRapnsNotifications < ActiveRecord::Migration
     create_table :rapns_notifications do |t|
       t.integer   :badge,                 :null => true
       t.string    :device_token,          :null => false, :limit => 64
-      t.string    :sound,                 :null => true,  :default => "default"
+      t.string    :sound,                 :null => true,  :default => "1.aiff"
       t.string    :alert,                 :null => true
       t.text      :attributes_for_device, :null => true
       t.integer   :expiry,                :null => false, :default => 1.day.to_i

--- a/lib/generators/templates/create_rapns_notifications.rb
+++ b/lib/generators/templates/create_rapns_notifications.rb
@@ -3,7 +3,7 @@ class CreateRapnsNotifications < ActiveRecord::Migration
     create_table :rapns_notifications do |t|
       t.integer   :badge,                 :null => true
       t.string    :device_token,          :null => false, :limit => 64
-      t.string    :sound,                 :null => true,  :default => "1.aiff"
+      t.string    :sound,                 :null => true,  :default => "default"
       t.string    :alert,                 :null => true
       t.text      :attributes_for_device, :null => true
       t.integer   :expiry,                :null => false, :default => 1.day.to_i

--- a/lib/rapns/apns/notification.rb
+++ b/lib/rapns/apns/notification.rb
@@ -8,6 +8,7 @@ module Rapns
 
       validates_with Rapns::Apns::DeviceTokenFormatValidator
       validates_with Rapns::Apns::BinaryNotificationValidator
+      validate :validate_required_fields
 
       alias_method :attributes_for_device=, :data=
       alias_method :attributes_for_device, :data
@@ -79,6 +80,18 @@ module Rapns
         id_for_pack = options[:for_validation] ? 0 : id
         [1, id_for_pack, expiry, 0, 32, device_token, payload_size, payload].pack("cNNccH*na*")
       end
+
+
+      private
+
+      # Notifications must contain one of alert, badge or sound as per:
+      # https://developer.apple.com/library/ios/#documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/ApplePushService/ApplePushService.html
+      def validate_required_fields
+        if alert.nil? && badge.nil? && sound.nil?
+          errors[:base] << "APN Notification must contain one of alert, badge, or sound"
+        end
+      end
+
     end
   end
 end

--- a/spec/unit/apns/notification_spec.rb
+++ b/spec/unit/apns/notification_spec.rb
@@ -25,12 +25,22 @@ describe Rapns::Apns::Notification do
     notification.errors[:base].include?("APN notification cannot be larger than 256 bytes. Try condensing your alert and device attributes.").should be_true
   end
 
-  it "should default the sound to 1.aiff" do
-    notification.sound.should == "1.aiff"
+  it "should default the sound to 'default'" do
+    notification.sound.should eq('default')
   end
 
   it "should default the expiry to 1 day" do
     notification.expiry.should == 1.day.to_i
+  end
+
+  # The notification must contain one of alert, sound or badge.
+  # @see https://developer.apple.com/library/ios/#documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/ApplePushService/ApplePushService.html
+  it "should not be valid if there is none of alert,sound,badge present" do
+    notification.alert = nil
+    notification.sound = nil
+    notification.badge = nil
+    notification.valid?.should be_false
+    notification.errors[:base].should include("APN Notification must contain one of alert, badge, or sound")
   end
 end
 


### PR DESCRIPTION
Hi,

The current apple docs suggest using the value of "default" to play a default sound. I can't see "1.aiff" anywhere. It is still optional, but having a default value shows people how to use the default sound and its not hard to use nil explicitly if the user wants to (as I already do).

I also added a test in here to validate that one of alert, badge or sound is present as is specified in the apple docs:

https://developer.apple.com/library/ios/#documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/ApplePushService/ApplePushService.html
