### PR TITLE
Queue and QueueStatus for rapns

### DIFF
--- a/bin/rapns
+++ b/bin/rapns
@@ -17,6 +17,7 @@ ARGV.options do |opts|
   opts.on('-n', '--no-airbrake-notify', 'Disables error notifications via Airbrake.') { config.check_for_errors = false }
   opts.on('-p PATH', '--pid-file PATH', String, 'Path to write PID file. Relative to Rails root unless absolute.') { |path| config.pid_file = path }
   opts.on('-b N', '--batch-size N', Integer, 'ActiveRecord notifications batch size.') { |n| config.batch_size = n }
+  opts.on('-q QUEUE_NAME', '--queue NAME', String, 'Name of the queue. Default: nil. Specify a name of the queue for this rapns instance to process only.') { |queue| config.queue = queue }
   opts.on('-v', '--version', 'Print this version of rapns.') { puts "rapns #{Rapns::VERSION}"; exit }
   opts.on('-h', '--help', 'You\'re looking at it.') { puts opts; exit }
   opts.parse!

--- a/lib/generators/rapns_generator.rb
+++ b/lib/generators/rapns_generator.rb
@@ -16,6 +16,7 @@ class RapnsGenerator < Rails::Generators::Base
     add_rapns_migration('add_app_to_rapns')
     add_rapns_migration('create_rapns_apps')
     add_rapns_migration('add_gcm')
+    add_rapns_migration('add_queue_to_rapns_notifications')
   end
 
   protected

--- a/lib/generators/templates/add_queue_to_rapns_notifications.rb
+++ b/lib/generators/templates/add_queue_to_rapns_notifications.rb
@@ -1,0 +1,9 @@
+class AddQueueToRapnsNotifications < ActiveRecord::Migration
+  def self.up
+    add_column :rapns_notifications, :queue, :boolean, :null => true
+  end
+
+  def self.down
+    remove_column :rapns_notifications, :queue
+  end
+end

--- a/lib/generators/templates/create_rapns_queue_statuses.rb
+++ b/lib/generators/templates/create_rapns_queue_statuses.rb
@@ -1,0 +1,17 @@
+class CreateRapnsQueueStatuses < ActiveRecord::Migration
+  def self.up
+    create_table :rapns_queue_statuses do |t|
+      t.string    :queue,             :null => false
+      t.datetime  :heart_beat_at,     :null => true
+      t.integer   :sent_count,        :null => true, :default => 1
+      t.integer   :failed_count,      :null => true, :default => 1
+      t.timestamps
+    end
+
+    add_index :rapns_queue_statuses, :queue, :unique => true
+  end
+
+  def self.down
+    drop_table :rapns_queue_statuses
+  end
+end

--- a/lib/rapns/apns/queue_status.rb
+++ b/lib/rapns/apns/queue_status.rb
@@ -1,0 +1,28 @@
+module Rapns
+  module Apns
+    class QueueStatus < ActiveRecord::Base
+      self.table_name = 'rapns_queue_statuses'
+
+      attr_accessible :queue, :heart_beat_at, :sent_count, :failed_count
+
+      def self.queue_status(queue)
+        QueueStatus.find_or_create_by_queue(queue)
+      end
+
+      def self.sent_ok(queue)
+        return unless queue
+        self.queue_status(queue).increment!(:sent_count)
+      end
+
+      def self.sent_failed(queue)
+        return unless queue
+        self.queue_status(queue).increment!(:failed_count)
+      end
+
+      def self.heart_beat(queue)
+        return unless queue
+        self.queue_status(queue).update_column(:heart_beat_at, Time.new)
+      end
+    end
+  end
+end

--- a/lib/rapns/configuration.rb
+++ b/lib/rapns/configuration.rb
@@ -14,7 +14,7 @@ module Rapns
   end
 
   # A class to hold Rapns configuration settings and callbacks.
-  class Configuration < Struct.new(:foreground, :push_poll, :feedback_poll, :airbrake_notify, :check_for_errors, :pid_file, :batch_size)
+  class Configuration < Struct.new(:foreground, :push_poll, :feedback_poll, :airbrake_notify, :check_for_errors, :pid_file, :batch_size, :queue)
 
     attr_accessor :feedback_callback
 
@@ -29,6 +29,7 @@ module Rapns
       self.airbrake_notify = true
       self.check_for_errors = true
       self.batch_size = 5000
+      self.queue = nil
     end
 
     # Define a block that will be executed with a Rapns::Feedback instance when feedback has been received from the

--- a/lib/rapns/daemon.rb
+++ b/lib/rapns/daemon.rb
@@ -47,6 +47,10 @@ module Rapns
       write_pid_file
       ensure_upgraded
       AppRunner.sync
+
+      @app_sync = AppSync.new
+      @app_sync.start
+
       Feeder.start(config.push_poll)
     end
 
@@ -97,6 +101,9 @@ module Rapns
       puts "\nShutting down..."
       Feeder.stop
       AppRunner.stop
+
+      @app_sync.stop
+
       delete_pid_file
     end
 

--- a/lib/rapns/daemon/app_sync.rb
+++ b/lib/rapns/daemon/app_sync.rb
@@ -1,0 +1,35 @@
+module Rapns
+  module Daemon
+    class AppSync
+      include InterruptibleSleep
+
+      def initialize(poll = 60)
+        @poll = poll
+      end
+
+      def start
+        @thread = Thread.new do
+          loop do
+            break if @stop
+            interruptible_sleep @poll
+            check_for_sync
+          end
+        end
+      end
+
+      def stop
+        @stop = true
+        interrupt_sleep
+        @thread.join if @thread
+      end
+
+      def check_for_sync
+        Rapns::Daemon.logger.info("[AppSync]")
+
+        QueueStatus.heart_beat(Rapns::Daemon.config.queue)
+
+        AppRunner.sync
+      end
+    end
+  end
+end

--- a/lib/rapns/daemon/delivery_handler.rb
+++ b/lib/rapns/daemon/delivery_handler.rb
@@ -39,8 +39,10 @@ module Rapns
 
         begin
           deliver(notification)
+          QueueStatus.sent_ok(Rapns::Daemon.config.queue)
         rescue StandardError => e
           Rapns::Daemon.logger.error(e)
+          QueueStatus.sent_failed(Rapns::Daemon.config.queue)
         ensure
           queue.notification_processed
         end

--- a/lib/rapns/notification.rb
+++ b/lib/rapns/notification.rb
@@ -25,6 +25,10 @@ module Rapns
       where(:app_id => apps.map(&:id))
     }
 
+    scope :for_queue, lambda { |queue|
+      where(:queue => queue)
+    }
+    
     def initialize(attributes = nil, options = {})
       if attributes.is_a?(Hash) && attributes.keys.include?(:attributes_for_device)
         msg = ":attributes_for_device via mass-assignment is deprecated. Use :data or the attributes_for_device= instance method."


### PR DESCRIPTION
Specifying a queue parameter when starting up a rapns instance, in order to support multiple instances of rapns in the same server or multiple servers.

Also added a QueueStatus ActiveRecord to monitor the sent_count, failed_count and heart_beart information of the rapns instance.

Added a AppSync object to sync the apps every 60 seconds and also update the heart beat of the instance.
I think it's easier to let the Instance sync the apps by itself when there are tens of instances rather than do `kill -USR1 pid`.

In my project, I start 10 instances in each server and there are 3 servers totally, all the 30 instances working fine so far.

This is basically a draft of my idea to run the rapns in multiple servers and I failed to run the `rake test`.
So no spec test for this yet.

Please let me know if this idea work or not. And then I could start to add test cases for it.

One problem is that there is probably no need to start feedback service for every instance.

Below it's the problem when I run `ADAPTER=mysql2 bundle exec rake`.

```
Using mysql2 adapter.
-- drop_table(:rapns_notifications)
-- create_table(:rapns_notifications)
/Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/activerecord-3.2.9/lib/active_record/connection_adapters/mysql_adapter.rb:411:in `real_connect': Access denied for user ''@'localhost' to database 'rapns_test' (Mysql::Error)
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/activerecord-3.2.9/lib/active_record/connection_adapters/mysql_adapter.rb:411:in `connect'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/activerecord-3.2.9/lib/active_record/connection_adapters/mysql_adapter.rb:131:in `initialize'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/activerecord-3.2.9/lib/active_record/connection_adapters/mysql_adapter.rb:38:in `new'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/activerecord-3.2.9/lib/active_record/connection_adapters/mysql_adapter.rb:38:in `mysql_connection'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/activerecord-3.2.9/lib/active_record/connection_adapters/abstract/connection_pool.rb:315:in `new_connection'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/activerecord-3.2.9/lib/active_record/connection_adapters/abstract/connection_pool.rb:325:in `checkout_new_connection'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/activerecord-3.2.9/lib/active_record/connection_adapters/abstract/connection_pool.rb:247:in `block (2 levels) in checkout'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/activerecord-3.2.9/lib/active_record/connection_adapters/abstract/connection_pool.rb:242:in `loop'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/activerecord-3.2.9/lib/active_record/connection_adapters/abstract/connection_pool.rb:242:in `block in checkout'
    from /Users/wushaokun/.rvm/rubies/ruby-1.9.2-p320/lib/ruby/1.9.1/monitor.rb:201:in `mon_synchronize'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/activerecord-3.2.9/lib/active_record/connection_adapters/abstract/connection_pool.rb:239:in `checkout'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/activerecord-3.2.9/lib/active_record/connection_adapters/abstract/connection_pool.rb:102:in `block in connection'
    from /Users/wushaokun/.rvm/rubies/ruby-1.9.2-p320/lib/ruby/1.9.1/monitor.rb:201:in `mon_synchronize'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/activerecord-3.2.9/lib/active_record/connection_adapters/abstract/connection_pool.rb:101:in `connection'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/activerecord-3.2.9/lib/active_record/connection_adapters/abstract/connection_pool.rb:410:in `retrieve_connection'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/activerecord-3.2.9/lib/active_record/connection_adapters/abstract/connection_specification.rb:171:in `retrieve_connection'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/activerecord-3.2.9/lib/active_record/connection_adapters/abstract/connection_specification.rb:145:in `connection'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/activerecord-3.2.9/lib/active_record/migration.rb:452:in `connection'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/activerecord-3.2.9/lib/active_record/migration.rb:465:in `block in method_missing'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/activerecord-3.2.9/lib/active_record/migration.rb:438:in `block in say_with_time'
    from /Users/wushaokun/.rvm/rubies/ruby-1.9.2-p320/lib/ruby/1.9.1/benchmark.rb:295:in `measure'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/activerecord-3.2.9/lib/active_record/migration.rb:438:in `say_with_time'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/activerecord-3.2.9/lib/active_record/migration.rb:458:in `method_missing'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/activerecord-3.2.9/lib/active_record/migration.rb:334:in `method_missing'
    from /Users/wushaokun/workspace/rapns/lib/generators/templates/create_rapns_notifications.rb:3:in `up'
    from /Users/wushaokun/workspace/rapns/spec/unit_spec_helper.rb:50:in `block in <top (required)>'
    from /Users/wushaokun/workspace/rapns/spec/unit_spec_helper.rb:47:in `each'
    from /Users/wushaokun/workspace/rapns/spec/unit_spec_helper.rb:47:in `<top (required)>'
    from /Users/wushaokun/workspace/rapns/spec/acceptance_spec_helper.rb:1:in `require'
    from /Users/wushaokun/workspace/rapns/spec/acceptance_spec_helper.rb:1:in `<top (required)>'
    from /Users/wushaokun/workspace/rapns/spec/acceptance/gcm_upgrade_spec.rb:1:in `require'
    from /Users/wushaokun/workspace/rapns/spec/acceptance/gcm_upgrade_spec.rb:1:in `<top (required)>'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/rspec-core-2.12.1/lib/rspec/core/configuration.rb:789:in `load'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/rspec-core-2.12.1/lib/rspec/core/configuration.rb:789:in `block in load_spec_files'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/rspec-core-2.12.1/lib/rspec/core/configuration.rb:789:in `each'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/rspec-core-2.12.1/lib/rspec/core/configuration.rb:789:in `load_spec_files'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/rspec-core-2.12.1/lib/rspec/core/command_line.rb:22:in `run'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/rspec-core-2.12.1/lib/rspec/core/runner.rb:80:in `run'
    from /Users/wushaokun/.rvm/gems/ruby-1.9.2-p320@rapns/gems/rspec-core-2.12.1/lib/rspec/core/runner.rb:17:in `block in autorun'
```
