### PR TITLE
Fixed daemonization for Ruby 1.9 compatibility

### DIFF
--- a/lib/rapns/daemon.rb
+++ b/lib/rapns/daemon.rb
@@ -121,16 +121,17 @@ Remove config/rapns/rapns.yml to avoid this warning.
 
     # :nocov:
     def self.daemonize
-      exit if pid = fork
-      Process.setsid
-      exit if pid = fork
-
-      Dir.chdir '/'
-      File.umask 0000
-
-      STDIN.reopen '/dev/null'
-      STDOUT.reopen '/dev/null', 'a'
-      STDERR.reopen STDOUT
+      if RUBY_VERSION < "1.9"
+        exit if fork
+        Process.setsid
+        exit if fork
+        Dir.chdir "/" 
+        STDIN.reopen "/dev/null"
+        STDOUT.reopen "/dev/null", "a" 
+        STDERR.reopen "/dev/null", "a" 
+      else
+        Process.daemon
+      end 
     end
   end
 end


### PR DESCRIPTION
Ruby 1.9 has a handy Process.daemon method that doesn't seem to cause problems creating the PID file.
