### PR TITLE
Fix issue with integration with ActiveScaffold

### DIFF
--- a/lib/rapns/app.rb
+++ b/lib/rapns/app.rb
@@ -4,7 +4,7 @@ module Rapns
 
     attr_accessible :name, :environment, :certificate, :password, :connections, :auth_key
 
-    has_many :notifications
+    has_many :notifications, :class_name => 'Rapns::Notification'
 
     validates :name, :presence => true, :uniqueness => { :scope => [:type, :environment] }
     validates_numericality_of :connections, :greater_than => 0, :only_integer => true


### PR DESCRIPTION
ActiveScaffold failures when attempting to introspect the notifications associated on Rapns::App. Added an explicit class declaration to prevent this introspection failure.
