### PR TITLE
Add 'insane_notify' options

### DIFF
--- a/bin/rapns
+++ b/bin/rapns
@@ -19,6 +19,7 @@ ARGV.options do |opts|
   opts.on('-P N', '--db-poll N', Integer, "Frequency in seconds to check for new notifications. Default: #{config.push_poll}.") { |n| config.push_poll = n }
   opts.on('-F N', '--feedback-poll N', Integer, "Frequency in seconds to check for feedback. Default: #{config.feedback_poll}.") { |n| config.feedback_poll = n }
   opts.on('-e', '--no-error-checks', 'Disable APNs error checking after notification delivery.') { config.check_for_errors = false }
+  opts.on('-i', '--insane-notify', 'Mark delivered bofore notification delivery.') { config.insane_notify = true }
   opts.on('-n', '--no-airbrake-notify', 'Disables error notifications via Airbrake.') { config.airbrake_notify = false }
   opts.on('-p PATH', '--pid-file PATH', String, 'Path to write PID file. Relative to Rails root unless absolute.') { |path| config.pid_file = path }
   opts.on('-b N', '--batch-size N', Integer, 'ActiveRecord notifications batch size.') { |n| config.batch_size = n }

--- a/lib/generators/templates/rapns.rb
+++ b/lib/generators/templates/rapns.rb
@@ -17,6 +17,9 @@
   # Disable APNs error checking after notification delivery.
   # config.check_for_errors = true
 
+  # Mark delivered bofore notification delivery.
+  # config.insane_notify = false
+
   # ActiveRecord notifications batch size.
   # config.batch_size = 5000
 

--- a/lib/rapns/configuration.rb
+++ b/lib/rapns/configuration.rb
@@ -8,7 +8,7 @@ module Rapns
   end
 
   CONFIG_ATTRS = [:foreground, :push_poll, :feedback_poll, :embedded,
-    :airbrake_notify, :check_for_errors, :pid_file, :batch_size,
+    :airbrake_notify, :check_for_errors, :insane_notify, :pid_file, :batch_size,
     :push]
 
   class ConfigurationWithoutDefaults < Struct.new(*CONFIG_ATTRS)
@@ -67,6 +67,7 @@ module Rapns
       self.feedback_poll = 60
       self.airbrake_notify = true
       self.check_for_errors = true
+      self.insane_notify = false
       self.batch_size = 5000
       self.pid_file = nil
       self.apns_feedback_callback = nil

--- a/lib/rapns/daemon/apns/delivery.rb
+++ b/lib/rapns/daemon/apns/delivery.rb
@@ -26,7 +26,7 @@ module Rapns
           begin
             @connection.write(@notification.to_binary)
             check_for_error if Rapns.config.check_for_errors
-            mark_delivered
+            mark_delivered unless Rapns.config.insane_notify
             Rapns::Daemon.logger.info("[#{@app.name}] #{@notification.id} sent to #{@notification.device_token}")
           rescue Rapns::DeliveryError, Rapns::Apns::DisconnectionError => error
             mark_failed(error.code, error.description)

--- a/lib/rapns/daemon/feeder.rb
+++ b/lib/rapns/daemon/feeder.rb
@@ -43,7 +43,9 @@ module Rapns
             idle = Rapns::Daemon::AppRunner.idle.map(&:app)
             relation = Rapns::Notification.ready_for_delivery.for_apps(idle)
             relation = relation.limit(batch_size) unless Rapns.config.push
-            relation.each do |notification|
+            notifications = relation.to_a
+            relation.update_all delivered: true if Rapns.config.insane_notify
+            notifications.each do |notification|
               Rapns::Daemon::AppRunner.enqueue(notification)
               reflect(:notification_enqueued, notification)
             end

--- a/lib/rapns/daemon/gcm/delivery.rb
+++ b/lib/rapns/daemon/gcm/delivery.rb
@@ -46,7 +46,7 @@ module Rapns
           body = multi_json_load(response.body)
 
           if body['failure'].to_i == 0
-            mark_delivered
+            mark_delivered unless Rapns.config.insane_notify
             Rapns::Daemon.logger.info("[#{@app.name}] #{@notification.id} sent to #{@notification.registration_ids.join(', ')}")
           else
             handle_errors(response, body)

--- a/spec/unit/daemon/apns/delivery_spec.rb
+++ b/spec/unit/daemon/apns/delivery_spec.rb
@@ -65,6 +65,12 @@ describe Rapns::Daemon::Apns::Delivery do
     perform
   end
 
+  it 'does not mark delivered insane_notify config option is true' do
+    config.stub(:insane_notify => true)
+    delivery.should_not_receive(:mark_delivered)
+    perform
+  end
+
   describe "when delivery fails" do
     before { connection.stub(:select => true, :read => [8, 4, 69].pack("ccN")) }
 

--- a/spec/unit/daemon/gcm/delivery_spec.rb
+++ b/spec/unit/daemon/gcm/delivery_spec.rb
@@ -30,6 +30,12 @@ describe Rapns::Daemon::Gcm::Delivery do
       end.to change(notification, :delivered).to(true)
     end
 
+    it 'does not mark delivered insane_notify config option is true' do
+      config.stub(:insane_notify => true)
+      delivery.should_not_receive(:mark_delivered)
+      perform
+    end
+
     it 'reflects the notification was delivered' do
       response.stub(:body => JSON.dump({ 'failure' => 0 }))
       delivery.should_receive(:reflect).with(:notification_delivered, notification)


### PR DESCRIPTION
This pull-request is a proposal.
Enable 'insame_notify' option will be faster sending.

It became 150 minutes to 8 minutes in my environment.

> @75,000 APNs devices, 1 connection, ec2 micro, no_check_for_error

To save the 'delivered' flag each sending, causes the IO wait of DB.
The 'insame_notify' change to mark delivered before taking to handles.

Note:
- If application crashed, it will not be sent up to 5,000 (batch_size) notifications
- `delivered_at` is always not set
