### PR TITLE
Add support for switching the daemon logger.

### DIFF
--- a/lib/rapns/configuration.rb
+++ b/lib/rapns/configuration.rb
@@ -9,7 +9,7 @@ module Rapns
 
   CONFIG_ATTRS = [:foreground, :push_poll, :feedback_poll, :embedded,
     :airbrake_notify, :check_for_errors, :pid_file, :batch_size,
-    :push, :store]
+    :push, :store, :logger]
 
   class ConfigurationWithoutDefaults < Struct.new(*CONFIG_ATTRS)
   end
@@ -37,6 +37,10 @@ module Rapns
       else
         super
       end
+    end
+
+    def logger=(logger)
+      super(logger)
     end
 
     def foreground=(bool)
@@ -71,6 +75,7 @@ module Rapns
       self.pid_file = nil
       self.apns_feedback_callback = nil
       self.store = :active_record
+      self.logger = nil
 
       # Internal options.
       self.embedded = false

--- a/lib/rapns/daemon/apns/connection.rb
+++ b/lib/rapns/daemon/apns/connection.rb
@@ -49,7 +49,7 @@ module Rapns
 
           begin
             write_data(data)
-          rescue Errno::EPIPE, Errno::ETIMEDOUT, OpenSSL::SSL::SSLError => e
+          rescue Errno::EPIPE, Errno::ETIMEDOUT, OpenSSL::SSL::SSLError, IOError => e
             retry_count += 1;
 
             if retry_count == 1

--- a/lib/rapns/logger.rb
+++ b/lib/rapns/logger.rb
@@ -6,7 +6,9 @@ module Rapns
       begin
         log = File.open(File.join(Rails.root, 'log', 'rapns.log'), 'a')
         log.sync = true
-        if defined?(ActiveSupport::BufferedLogger)
+        if Rapns.config.logger
+          @logger = Rapns.config.logger
+        elsif defined?(ActiveSupport::BufferedLogger)
           @logger = ActiveSupport::BufferedLogger.new(log, Rails.logger.level)
           @logger.auto_flushing = Rails.logger.respond_to?(:auto_flushing) ? Rails.logger.auto_flushing : true
         else

--- a/spec/unit/daemon/apns/connection_spec.rb
+++ b/spec/unit/daemon/apns/connection_spec.rb
@@ -185,6 +185,14 @@ describe Rapns::Daemon::Apns::Connection do
     end
   end
 
+  describe "when write raises an IOError" do
+    it_should_behave_like "when the write fails"
+
+    def error_type
+      IOError
+    end
+  end
+
   describe "when reconnecting" do
     it 'closes the socket' do
       connection.should_receive(:close)

--- a/spec/unit/daemon_spec.rb
+++ b/spec/unit/daemon_spec.rb
@@ -7,7 +7,8 @@ describe Rapns::Daemon, "when starting" do
   let(:certificate) { stub }
   let(:password) { stub }
   let(:config) { stub(:pid_file => nil, :airbrake_notify => false,
-    :foreground => true, :embedded => false, :push => false, :store => :active_record) }
+    :foreground => true, :embedded => false, :push => false,
+    :store => :active_record, :logger => nil) }
   let(:logger) { stub(:logger, :info => nil, :error => nil, :warn => nil) }
 
   before do
@@ -102,6 +103,7 @@ end
 
 describe Rapns::Daemon, "when being shutdown" do
   let(:config) { stub(:pid_file => '/rails_root/rapns.pid') }
+  let(:logger) { stub(:info => nil, :error => nil, :warn => nil) }
 
   before do
     Rapns.stub(:config => config)


### PR DESCRIPTION
This pull request adds support for configuring a custom logger. (Because we need to set our own logger in the rapns configuration)
