### PR TITLE
Allow nested hashes in notification attributes.

### DIFF
--- a/lib/rapns/apns/notification.rb
+++ b/lib/rapns/apns/notification.rb
@@ -69,7 +69,7 @@ module Rapns
 
           if attributes_for_device
             non_aps_attributes = attributes_for_device.reject { |k, v| k == CONTENT_AVAILABLE_KEY }
-            non_aps_attributes.each { |k, v| json[k.to_s] = v.to_s }
+            non_aps_attributes.each { |k, v| json[k.to_s] = v }
           end
         end
 

--- a/spec/unit/apns/notification_spec.rb
+++ b/spec/unit/apns/notification_spec.rb
@@ -97,6 +97,13 @@ describe Rapns::Apns::Notification, "as_json" do
     notification.as_json["omg"].should == "lol"
     notification.as_json["wtf"].should == "dunno"
   end
+
+  it "should allow attributes to include a hash" do
+    notification = Rapns::Apns::Notification.new
+    notification.attributes_for_device = {:omg => {:ilike => :hashes}}
+    notification.as_json["omg"]["ilike"].should == "hashes"
+  end
+
 end
 
 describe Rapns::Apns::Notification, 'MDM' do


### PR DESCRIPTION
This commit allows you to add a hash as a nested attribute in the payload of a notification.  Otherwise the nested hash shows up as an NSString in the userInfo dictionary.
