### PR TITLE
Rapns App Per Rails Environment

### DIFF
--- a/lib/generators/rapns_generator.rb
+++ b/lib/generators/rapns_generator.rb
@@ -16,6 +16,7 @@ class RapnsGenerator < Rails::Generators::Base
     add_rapns_migration('add_app_to_rapns')
     add_rapns_migration('create_rapns_apps')
     add_rapns_migration('add_gcm')
+    add_rapns_migration('add_rails_env_to_rapns_app')
   end
 
    def copy_config

--- a/lib/generators/templates/add_rails_env_to_rapns_app.rb
+++ b/lib/generators/templates/add_rails_env_to_rapns_app.rb
@@ -1,0 +1,9 @@
+class AddRailsEnvToRapnsApp < ActiveRecord::Migration
+  def self.up
+    add_column :rapns_apps, :rails_env, :string
+  end
+
+  def self.down
+    remove_column :rapns_apps, :rails_env
+  end
+end

--- a/lib/rapns/app.rb
+++ b/lib/rapns/app.rb
@@ -2,7 +2,7 @@ module Rapns
   class App < ActiveRecord::Base
     self.table_name = 'rapns_apps'
 
-    attr_accessible :name, :environment, :certificate, :password, :connections, :auth_key
+    attr_accessible :name, :environment, :certificate, :password, :connections, :auth_key, :rails_env
 
     has_many :notifications, :class_name => 'Rapns::Notification'
 
@@ -10,6 +10,10 @@ module Rapns
     validates_numericality_of :connections, :greater_than => 0, :only_integer => true
 
     validate :certificate_has_matching_private_key
+
+    before_validation :set_rails_env, :on => :create, :unless => :rails_env?
+
+    default_scope { where(:rails_env => Rails.env) }
 
     private
 
@@ -24,6 +28,10 @@ module Rapns
         end
       end
       result
+    end
+
+    def set_rails_env
+      self.rails_env = Rails.env
     end
   end
 end

--- a/spec/acceptance/gcm_upgrade_spec.rb
+++ b/spec/acceptance/gcm_upgrade_spec.rb
@@ -21,13 +21,22 @@ describe 'GCM upgrade' do
       SQL
     end
 
-    migrate('add_gcm', 'add_rails_env_to_rapns_app')
+    migrate('add_gcm')
+
+    migrate('add_rails_env_to_rapns_app')
+
+    as_test_rails_db do
+      ActiveRecord::Base.connection.execute <<-SQL
+        UPDATE rapns_apps SET rails_env='#{Rails.env}'
+      SQL
+    end
   end
 
   it 'associates apps and notifications' do
     as_test_rails_db do
       app = Rapns::Apns::App.first
       app.name.should == 'test'
+      app.rails_env.should == Rails.env
       app.notifications.count.should == 1
     end
   end

--- a/spec/acceptance/gcm_upgrade_spec.rb
+++ b/spec/acceptance/gcm_upgrade_spec.rb
@@ -21,7 +21,7 @@ describe 'GCM upgrade' do
       SQL
     end
 
-    migrate('add_gcm')
+    migrate('add_gcm', 'add_rails_env_to_rapns_app')
   end
 
   it 'associates apps and notifications' do

--- a/spec/unit/app_spec.rb
+++ b/spec/unit/app_spec.rb
@@ -13,4 +13,17 @@ describe Rapns::App do
     app = Rapns::Gcm::App.new(:name => 'test', :environment => 'production', :auth_key => TEST_CERT)
     app.valid?.should be_true
   end
+
+  it "saves the rails environment" do
+    app = Rapns::Apns::App.create!(:name => 'test', :environment => 'production', :certificate => TEST_CERT)
+    app.rails_env.should eql 'test'
+
+    app = Rapns::Apns::App.create!(:name => 'test2', :environment => 'production', :certificate => TEST_CERT, :rails_env => 'production')
+    app.rails_env.should eql 'production'
+  end
+
+  it "has a default scope to load only the apps in the rails environment" do
+    Rapns::App.scoped.to_sql.should eql Rapns::App.where(:rails_env => Rails.env).to_sql
+  end
+
 end

--- a/spec/unit_spec_helper.rb
+++ b/spec/unit_spec_helper.rb
@@ -26,7 +26,7 @@ if ENV['TRAVIS']
   DATABASE_CONFIG[$adapter]['username'] = 'postgres'
 else
   require 'etc'
-  DATABASE_CONFIG[$adapter]['username'] = Etc.getlogin
+  DATABASE_CONFIG[$adapter]['username'] = Etc.getlogin if DATABASE_CONFIG[$adapter]['username'].nil?
 end
 
 puts "Using #{$adapter} adapter."
@@ -39,9 +39,10 @@ require 'generators/templates/add_alert_is_json_to_rapns_notifications'
 require 'generators/templates/add_app_to_rapns'
 require 'generators/templates/create_rapns_apps'
 require 'generators/templates/add_gcm'
+require 'generators/templates/add_rails_env_to_rapns_app'
 
 [CreateRapnsNotifications, CreateRapnsFeedback,
- AddAlertIsJsonToRapnsNotifications, AddAppToRapns, CreateRapnsApps, AddGcm].each do |migration|
+ AddAlertIsJsonToRapnsNotifications, AddAppToRapns, CreateRapnsApps, AddGcm, AddRailsEnvToRapnsApp].each do |migration|
   migration.down rescue ActiveRecord::StatementInvalid
   migration.up
 end


### PR DESCRIPTION
Added rails_env column to the rapns::apps table. This allows us to only send notifications for the rails environment that the notifications were created in.
