### PR TITLE
fix error in migration-generator template

### DIFF
--- a/lib/generators/templates/add_gcm.rb
+++ b/lib/generators/templates/add_gcm.rb
@@ -87,7 +87,6 @@ class AddGcm < ActiveRecord::Migration
       Rapns::Notification.update_all(['app = ?', app.key], ['app_id = ?', app.id])
     end
 
-    change_column :rapns_notifications, :key, :string, :null => false
     remove_column :rapns_notifications, :app_id
 
     remove_index :rapns_notifications, :name => "index_rapns_notifications_multi"


### PR DESCRIPTION
migration crashes when rolling back because of a missing field
