### PR TITLE
removed airbrake_notify defaults

### DIFF
--- a/lib/rapns/configuration.rb
+++ b/lib/rapns/configuration.rb
@@ -73,7 +73,6 @@ module Rapns
       self.push_poll = 2
       self.feedback_poll = 60
       Rapns::Deprecation.muted { self.airbrake_notify = true }
-      self.airbrake_notify = true
       self.check_for_errors = true
       self.batch_size = 5000
       self.pid_file = nil


### PR DESCRIPTION
Not sure if I'm doing it right, but, I don't want to see the deprecation message
`DEPRECATION WARNING: airbrake_notify is deprecated. Please use the Rapns.reflect API instead.` every time. I want to see it only if i'm using/setting airbrake_notify method in the configuration.

When airbrake_notify is set, then we'll get the deprecation warning, otherwise not.
