### PR TITLE
Prevent deprecation warning

### DIFF
--- a/lib/rapns/configuration.rb
+++ b/lib/rapns/configuration.rb
@@ -73,7 +73,6 @@ module Rapns
       self.push_poll = 2
       self.feedback_poll = 60
       Rapns::Deprecation.muted { self.airbrake_notify = true }
-      self.airbrake_notify = true
       self.check_for_errors = true
       self.batch_size = 5000
       self.pid_file = nil


### PR DESCRIPTION
Prevent `DEPRECATION WARNING: airbrake_notify is deprecated. Please use the Rapns.reflect API instead.`
