### PR TITLE
Feature: Notify / wake feeder via UDP socket

### DIFF
--- a/lib/rapns/configuration.rb
+++ b/lib/rapns/configuration.rb
@@ -9,7 +9,7 @@ module Rapns
 
   CONFIG_ATTRS = [:foreground, :push_poll, :feedback_poll, :embedded,
     :airbrake_notify, :check_for_errors, :pid_file, :batch_size,
-    :push, :store, :logger, :batch_storage_updates]
+    :push, :store, :logger, :batch_storage_updates, :udp_wake_host, :udp_wake_port]
 
   class ConfigurationWithoutDefaults < Struct.new(*CONFIG_ATTRS)
   end

--- a/lib/rapns/daemon/apns/feedback_receiver.rb
+++ b/lib/rapns/daemon/apns/feedback_receiver.rb
@@ -3,7 +3,6 @@ module Rapns
     module Apns
       class FeedbackReceiver
         include Reflectable
-        include InterruptibleSleep
 
         FEEDBACK_TUPLE_BYTES = 38
         HOSTS = {
@@ -25,14 +24,14 @@ module Rapns
             loop do
               break if @stop
               check_for_feedback
-              interruptible_sleep @poll
+              interruptible_sleep.sleep @poll
             end
           end
         end
 
         def stop
           @stop = true
-          interrupt_sleep
+          interruptible_sleep.interrupt_sleep
           @thread.join if @thread
         end
 
@@ -51,6 +50,10 @@ module Rapns
           ensure
             connection.close if connection
           end
+        end
+
+        def interrupt_sleep
+          interruptible_sleep.interrupt_sleep
         end
 
         protected
@@ -74,6 +77,12 @@ module Rapns
             Rapns.logger.error(e)
           end
         end
+
+        def interruptible_sleep
+          @interruptible_sleep ||= InterruptibleSleep.new
+        end
+
+
       end
     end
   end

--- a/lib/rapns/daemon/interruptible_sleep.rb
+++ b/lib/rapns/daemon/interruptible_sleep.rb
@@ -1,17 +1,62 @@
 module Rapns
   module Daemon
-    module InterruptibleSleep
-      def interruptible_sleep(seconds)
-        @_sleep_check, @_sleep_interrupt = IO.pipe
-        IO.select([@_sleep_check], nil, nil, seconds) rescue Errno::EINVAL
-        @_sleep_check.close rescue IOError
-        @_sleep_interrupt.close rescue IOError
+    class InterruptibleSleep
+
+      def initialize
+        @sleep_reader, @wake_writer = IO.pipe
       end
 
-      def interrupt_sleep
-        if @_sleep_interrupt
-          @_sleep_interrupt.close rescue IOError
+      # enable wake on receiving udp packets at the given address and port
+      # this returns the host,port used by bind in case an ephemeral port
+      # was indicated by specifying 0 as the port number.
+      # @return [String,Integer] host,port of bound UDP socket.
+      def enable_wake_on_udp(host, port)
+        @udp_wakeup = UDPSocket.new
+        @udp_wakeup.bind(host, port)
+        @udp_wakeup.addr.values_at(3,1)
+      end
+
+      # wait for the given timeout in seconds, or data was written to the pipe
+      # or the udp wakeup port if enabled.
+      # @return [boolean] true if the sleep was interrupted, or false
+      def sleep(timeout)
+        read_ports = [@sleep_reader]
+        read_ports << @udp_wakeup if @udp_wakeup
+        rs, = IO.select(read_ports, nil, nil, timeout) rescue nil
+
+        # consume all data on the readable io's so that our next call will wait for more data
+        if rs && rs.include?(@sleep_reader)
+          while true
+            begin
+              @sleep_reader.read_nonblock(1)
+            rescue IO::WaitReadable
+              break
+            end
+          end
         end
+
+        if rs && rs.include?(@udp_wakeup)
+          while true
+            begin
+              @udp_wakeup.recvmsg_nonblock
+            rescue IO::WaitReadable
+              break
+            end
+          end
+        end
+
+        !rs.nil? && rs.any?
+      end
+
+      # writing to the pipe will wake the sleeping thread
+      def interrupt_sleep
+        @wake_writer.write('.')
+      end
+
+      def close
+        @sleep_reader.close rescue nil
+        @wake_writer.close rescue nil
+        @udp_wakeup.close if @udp_wakeup rescue nil
       end
     end
   end

--- a/lib/rapns/notifier.rb
+++ b/lib/rapns/notifier.rb
@@ -1,0 +1,35 @@
+require 'socket'
+
+module Rapns
+  # This class notifies the sleeping Rapns Daemon that there are new Notifications to send,
+  # and to interrupt its sleep to send them immediately. The purpose of this is to allow
+  # much higher sleep times to reduce database polling activity.
+  class Notifier
+    def initialize(host, port)
+      @host, @port = host, port
+    end
+
+    # notify the daemon that there is a Notification to send.
+    def notify
+      socket.write('x')
+    end
+
+    # @return [UDPSocket]
+    def socket
+      if @socket.nil?
+        @socket = UDPSocket.new
+        @socket.connect(@host, @port)
+      end
+      @socket
+    end
+
+    # close the udp socket
+    def close
+      if @socket
+        @socket.close
+        @socket = nil
+      end
+    end
+
+  end
+end

--- a/spec/unit/daemon/apns/feedback_receiver_spec.rb
+++ b/spec/unit/daemon/apns/feedback_receiver_spec.rb
@@ -1,6 +1,7 @@
 require "unit_spec_helper"
 
 describe Rapns::Daemon::Apns::FeedbackReceiver, 'check_for_feedback' do
+
   let(:host) { 'feedback.push.apple.com' }
   let(:port) { 2196 }
   let(:poll) { 60 }
@@ -72,13 +73,17 @@ describe Rapns::Daemon::Apns::FeedbackReceiver, 'check_for_feedback' do
 
   it 'sleeps for the feedback poll period' do
     receiver.stub(:check_for_feedback)
-    receiver.should_receive(:interruptible_sleep).with(60).at_least(:once)
+    sleeper = double(Rapns::Daemon::InterruptibleSleep, :sleep => false)
+    sleeper.should_receive(:sleep).with(60).at_least(:once)
+    receiver.stub :interruptible_sleep => sleeper
     Thread.stub(:new).and_yield
     receiver.stub(:loop).and_yield
     receiver.start
   end
 
   it 'checks for feedback when started' do
+    sleeper = double(Rapns::Daemon::InterruptibleSleep, :sleep => false)
+    receiver.stub :interruptible_sleep => sleeper
     receiver.should_receive(:check_for_feedback).at_least(:once)
     Thread.stub(:new).and_yield
     receiver.stub(:loop).and_yield
@@ -86,8 +91,10 @@ describe Rapns::Daemon::Apns::FeedbackReceiver, 'check_for_feedback' do
   end
 
   it 'interrupts sleep when stopped' do
+    sleeper = double(Rapns::Daemon::InterruptibleSleep, :sleep => false)
+    receiver.stub :interruptible_sleep => sleeper
     receiver.stub(:check_for_feedback)
-    receiver.should_receive(:interrupt_sleep)
+    sleeper.should_receive(:interrupt_sleep)
     receiver.stop
   end
 

--- a/spec/unit/daemon/feeder_spec.rb
+++ b/spec/unit/daemon/feeder_spec.rb
@@ -1,8 +1,12 @@
 require "unit_spec_helper"
 
 describe Rapns::Daemon::Feeder do
-  let(:config) { double(:batch_size => 5000, :push_poll => 0, :embedded => false,
-    :push => false) }
+  let(:config) { double(:batch_size => 5000,
+                        :push_poll => 0,
+                        :embedded => false,
+                        :push => false,
+                        :udp_wake_host => nil,
+                        :udp_wake_port => nil) }
   let!(:app) { Rapns::Apns::App.create!(:name => 'my_app', :environment => 'development', :certificate => TEST_CERT) }
   let(:notification) { Rapns::Apns::Notification.create!(:device_token => "a" * 64, :app => app) }
   let(:logger) { double }
@@ -68,7 +72,9 @@ describe Rapns::Daemon::Feeder do
 
   it "sleeps for the given period" do
     config.stub(:push_poll => 2)
-    Rapns::Daemon::Feeder.should_receive(:interruptible_sleep).with(2)
+    sleeper = double(:sleep => true)
+    sleeper.should_receive(:sleep).with(2)
+    Rapns::Daemon::Feeder.stub(:interruptible_sleeper => sleeper)
     Rapns::Daemon::Feeder.stub(:loop).and_yield
     Rapns::Daemon::Feeder.start
   end

--- a/spec/unit/daemon/interruptible_sleep_spec.rb
+++ b/spec/unit/daemon/interruptible_sleep_spec.rb
@@ -1,40 +1,66 @@
 require "unit_spec_helper"
 
 describe Rapns::Daemon::InterruptibleSleep do
-  class SleepTest
-    extend Rapns::Daemon::InterruptibleSleep
-  end
 
   let(:rd) { double(:close => nil) }
   let(:wr) { double(:close => nil) }
 
-  before do
-    IO.stub(:pipe)
-    IO.stub(:select)
-  end
+  subject { Rapns::Daemon::InterruptibleSleep.new }
 
   it 'creates a new pipe' do
     IO.should_receive(:pipe)
-    SleepTest.interruptible_sleep 1
+    subject
   end
 
   it 'selects on the reader' do
     IO.stub(:pipe => [rd, wr])
     IO.should_receive(:select).with([rd], nil, nil, 1)
-    SleepTest.interruptible_sleep 1
-  end
-
-  it 'closes both ends of the pipe after the timeout' do
-    IO.stub(:pipe => [rd, wr])
-    rd.should_receive(:close)
-    wr.should_receive(:close)
-    SleepTest.interruptible_sleep 1
+    subject.sleep(1)
   end
 
   it 'closes the writer' do
     IO.stub(:pipe => [rd, wr])
-    SleepTest.interruptible_sleep 1
+    rd.should_receive(:close)
     wr.should_receive(:close)
-    SleepTest.interrupt_sleep
+    subject.close
   end
+
+  it 'returns false when timeout occurs' do
+    expect(subject.sleep(0.01)).to be_false
+  end
+
+  it 'returns true when sleep does not timeout' do
+    subject.interrupt_sleep
+    expect(subject.sleep(0.01)).to be_true
+  end
+
+  context 'with UDP socket connected' do
+    before :each do
+      @host, @port = subject.enable_wake_on_udp('127.0.0.1', 0)
+    end
+
+    it 'times out with no udp activity' do
+      expect(subject.sleep(0.01)).to be_false
+    end
+
+    it 'wakes on UDPSocket' do
+      waker = UDPSocket.new
+      waker.connect(@host, @port)
+      waker.write('x')
+      expect(subject.sleep(0.01)).to be_true
+    end
+
+    it 'consumes all data on udp socket' do
+      waker = UDPSocket.new
+      waker.connect(@host, @port)
+      waker.sendmsg('x')
+      waker.sendmsg('x')
+      waker.sendmsg('x')
+      # true since there is data to be read => no timeout
+      expect(subject.sleep(0.01)).to be_true
+      # false since data is consumed => wait for full timeout
+      expect(subject.sleep(0.01)).to be_false
+    end
+  end
+
 end

--- a/spec/unit/notifier_spec.rb
+++ b/spec/unit/notifier_spec.rb
@@ -1,0 +1,29 @@
+require 'unit_spec_helper'
+require 'rapns/notifier'
+
+describe Rapns::Notifier do
+
+  before(:each) { @port = 5000 }
+  subject { Rapns::Notifier.new('127.0.0.1', @port) }
+  its(:socket) { should_not be_nil }
+
+  context "when connected" do
+    before :each do
+      @reader = UDPSocket.new
+      @reader.bind('127.0.0.1', 0)
+      @port = @reader.addr[1]
+    end
+
+    describe "notify" do
+      it "calls write on the socket" do
+        UDPSocket.any_instance.should_receive(:write)
+        subject.notify
+      end
+
+      it "writes data that can be read from socket" do
+        subject.notify
+        expect(@reader.recvmsg).to be_an(Array)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This feature adds a class Rapns::Notifier which allows a web or other process to wake the Rapns daemon from sleep to send a notification immediately. This allows a much longer sleep time for lower polling / log activity.

Example notifier usage:

``` ruby
require 'rapns/notifier'
notifier = Rapns::Notifier.new(udp_host, udp_port)
notifier.notify # => wakes the daemon.
```

This is left as a separate require because it isn't used in the daemon, and can be used externally.
