### PR TITLE
Rapns Daemon wakeup: Refactor name of config variable...

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -15,7 +15,7 @@ jdbcpostgresql:
   password: ""
 
 mysql2:
-  adapter: mysql
+  adapter: mysql2
   database: rapns_test
   host: localhost
   username: rapns_test

--- a/lib/rapns.rb
+++ b/lib/rapns.rb
@@ -21,6 +21,7 @@ require 'rapns/embed'
 require 'rapns/push'
 require 'rapns/apns_feedback'
 require 'rapns/upgraded'
+require 'rapns/notifier'
 
 require 'rapns/apns/binary_notification_validator'
 require 'rapns/apns/device_token_format_validator'

--- a/lib/rapns/configuration.rb
+++ b/lib/rapns/configuration.rb
@@ -9,7 +9,7 @@ module Rapns
 
   CONFIG_ATTRS = [:foreground, :push_poll, :feedback_poll, :embedded,
     :airbrake_notify, :check_for_errors, :pid_file, :batch_size,
-    :push, :store, :logger, :batch_storage_updates, :udp_wake_host, :udp_wake_port]
+    :push, :store, :logger, :batch_storage_updates, :wakeup]
 
   class ConfigurationWithoutDefaults < Struct.new(*CONFIG_ATTRS)
   end

--- a/lib/rapns/daemon/feeder.rb
+++ b/lib/rapns/daemon/feeder.rb
@@ -53,8 +53,8 @@ module Rapns
       def self.interruptible_sleeper
         unless @interruptible_sleeper
           @interruptible_sleeper = InterruptibleSleep.new
-          if Rapns.config.udp_wake_host && Rapns.config.udp_wake_port
-            @interruptible_sleeper.enable_wake_on_udp Rapns.config.udp_wake_host, Rapns.config.udp_wake_port
+          if Rapns.config.wakeup
+            @interruptible_sleeper.enable_wake_on_udp Rapns.config.wakeup[:bind], Rapns.config.wakeup[:port]
           end
         end
         @interruptible_sleeper

--- a/lib/rapns/notifier.rb
+++ b/lib/rapns/notifier.rb
@@ -32,4 +32,21 @@ module Rapns
     end
 
   end
+
+  # Call this from a client application after saving a Notification to the database to wakeup the Rapns
+  # Daemon to deliver the notification immediately.
+  def self.wakeup
+    notifier.notify
+  end
+
+  # Default notifier instance. This uses the :connect, :port values in Rapns.config.wakeup to connect to the
+  # wakeup socket in the Rapns Daemon. It will fall back to :host, :port if :connect is not specified.
+  def self.notifier
+    unless @notifier
+      if Rapns.config.wakeup
+        @notifier = Notifier.new(Rapns.config.wakeup[:connect] || Rapns.config.wakeup[:host], Rapns.config.wakeup[:port])
+      end
+    end
+    @notifier
+  end
 end

--- a/spec/unit/notifier_spec.rb
+++ b/spec/unit/notifier_spec.rb
@@ -26,4 +26,24 @@ describe Rapns::Notifier do
       end
     end
   end
+
+  describe "default notifier" do
+    it "creates using :connect first" do
+      Rapns.config.stub :wakeup => { :connect => '127.0.0.1', :port => 1234 }
+      Rapns::Notifier.should_receive(:new).with('127.0.0.1', 1234)
+      Rapns.notifier
+    end
+
+    it "creates using :host next" do
+      Rapns.config.stub :wakeup => { :host => '127.0.0.1', :port => 1234 }
+      Rapns::Notifier.should_receive(:new).with('127.0.0.1', 1234)
+      Rapns.notifier
+    end
+
+    it "returns nil when wakeup is not specified" do
+      Rapns.config.stub :wakeup => nil
+      Rapns::Notifier.should_not_receive(:new)
+      expect(Rapns.notifier).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Rapns Daemon wakeup: Refactor name of config variable, and allow specification of separate bind/connect addresses.

Followup from #164
