### PR TITLE
remove uniqueness validation for app

### DIFF
--- a/lib/rapns/app.rb
+++ b/lib/rapns/app.rb
@@ -8,7 +8,7 @@ module Rapns
 
     has_many :notifications, :class_name => 'Rapns::Notification', :dependent => :destroy
 
-    validates :name, :presence => true, :uniqueness => { :scope => [:type, :environment] }
+    validates :name, :presence => true
     validates_numericality_of :connections, :greater_than => 0, :only_integer => true
   end
 end


### PR DESCRIPTION
The idea is that I'm using 

```
class Project < ActiveRecord::Base
  has_many :rapns_apps, class_name: 'Rapns::App', dependent: :destroy
end
```

And I do want to have same name in a project scope.
Rails doesn't provide a neat way to skip validation or modifying them in an inherited class, lets say.
So maybe a good idea is to disable it. I mean, I don't see the advantages.

I'm open to discussion regarding this. Maybe this is only my opinion.

N
