### PR TITLE
add individual GCM success and failure reflections per recipient. reorganize Gcm::Delivery class and specs.

### DIFF
--- a/lib/generators/templates/rapns.rb
+++ b/lib/generators/templates/rapns.rb
@@ -66,6 +66,12 @@ Rapns.reflect do |on|
   # on.apns_connection_lost do |app, error|
   # end
 
+  # Called for each recipient which successfully receives a notification. This
+  # can occur more than once for the same notification when there are multiple
+  # recipients.
+  # on.gcm_delivered_to_recipient do |notification, registration_id|
+  # end
+
   # Called when the GCM returns a canonical registration ID.
   # You will need to replace old_id with canonical_id in your records.
   # on.gcm_canonical_id do |old_id, canonical_id|

--- a/lib/generators/templates/rapns.rb
+++ b/lib/generators/templates/rapns.rb
@@ -72,6 +72,12 @@ Rapns.reflect do |on|
   # on.gcm_delivered_to_recipient do |notification, registration_id|
   # end
 
+  # Called for each recipient which fails to receive a notification. This
+  # can occur more than once for the same notification when there are multiple
+  # recipients. (do not handle invalid registration IDs here)
+  # on.gcm_failed_to_recipient do |notification, error, registration_id|
+  # end
+
   # Called when the GCM returns a canonical registration ID.
   # You will need to replace old_id with canonical_id in your records.
   # on.gcm_canonical_id do |old_id, canonical_id|

--- a/lib/rapns/daemon/gcm/delivery.rb
+++ b/lib/rapns/daemon/gcm/delivery.rb
@@ -222,9 +222,9 @@ module Rapns
             failures[category] = []
           end
 
-          @results_data.zip(@registration_ids).each_with_index do |(result, registration_id), index|
+          @results_data.each_with_index do |result, index|
             entry = {
-              registration_id: registration_id,
+              registration_id: @registration_ids[index],
               index: index
             }
             if result['message_id']

--- a/lib/rapns/reflection.rb
+++ b/lib/rapns/reflection.rb
@@ -13,7 +13,8 @@ module Rapns
     REFLECTIONS = [
       :apns_feedback, :notification_enqueued, :notification_delivered,
       :notification_failed, :notification_will_retry, :apns_connection_lost,
-      :gcm_canonical_id, :gcm_invalid_registration_id, :error, :apns_certificate_will_expire
+      :gcm_delivered_to_recipient, :gcm_canonical_id, :gcm_invalid_registration_id,
+      :error, :apns_certificate_will_expire
     ]
 
     REFLECTIONS.each do |reflection|

--- a/lib/rapns/reflection.rb
+++ b/lib/rapns/reflection.rb
@@ -13,8 +13,8 @@ module Rapns
     REFLECTIONS = [
       :apns_feedback, :notification_enqueued, :notification_delivered,
       :notification_failed, :notification_will_retry, :apns_connection_lost,
-      :gcm_delivered_to_recipient, :gcm_canonical_id, :gcm_invalid_registration_id,
-      :error, :apns_certificate_will_expire
+      :gcm_delivered_to_recipient, :gcm_failed_to_recipient, :gcm_canonical_id,
+      :gcm_invalid_registration_id, :error, :apns_certificate_will_expire
     ]
 
     REFLECTIONS.each do |reflection|


### PR DESCRIPTION
re: Gcm::Delivery reorganization:
the primary goal was to make code paths easier to follow in the case of a complete success, complete network fail/retry, and partial success/failure. even within these there are overlapping concerns, so the processing of the result data is unified into a new data structure (Gcm::Results) optimized for the different processing requirements - this happens first. from there the conditions leading to different side-effects are clearer. for example, there is now only one place where a DeliveryError is raised after a 200 response and one place where most of the error messages are generated for that.
the only functional change - apart from the two new reflections - is that in the case where all failures were invalid ids it used to mark the delivery as failed but not raise a DeliveryError - now it raises the error. also these error results are included in the error messages like ay others. the original behavior seemed incongruous and resulted in additional complexity. i can see a case for doing this so that one is effectively treating this class of errors (INVALID_REGISTRATION_ID_STATES) one way and others another way, but the UNAVAILABLE_STATES class of errors should then also be treated separately...
