### PR TITLE
Update Rapns::App validation to not swallow unexpected exceptions during validation

### DIFF
--- a/lib/rapns/apns/app.rb
+++ b/lib/rapns/apns/app.rb
@@ -10,10 +10,11 @@ module Rapns
       def certificate_has_matching_private_key
         result = false
         if certificate.present?
-          x509 = OpenSSL::X509::Certificate.new(certificate) rescue nil
-          pkey = OpenSSL::PKey::RSA.new(certificate, password) rescue nil
-          result = !x509.nil? && !pkey.nil?
-          unless result
+          begin
+            x509 = OpenSSL::X509::Certificate.new(certificate)
+            pkey = OpenSSL::PKey::RSA.new(certificate, password)
+            result = !x509.nil? && !pkey.nil?
+          rescue OpenSSL::OpenSSLError
             errors.add :certificate, 'Certificate value must contain a certificate and a private key.'
           end
         end

--- a/spec/unit/app_spec.rb
+++ b/spec/unit/app_spec.rb
@@ -13,4 +13,18 @@ describe Rapns::App do
     app = Rapns::Gcm::App.new(:name => 'test', :environment => 'production', :auth_key => TEST_CERT)
     app.valid?.should be_true
   end
+
+  context 'validating certificates' do
+    it 'rescues from certificate error' do
+      app = Rapns::Apns::App.new(:name => 'test', :environment => 'development', :certificate => 'bad')
+      expect{app.valid?}.not_to raise_error
+      expect(app.valid?).to be_false
+    end
+
+    it 'raises other errors' do
+      app = Rapns::Apns::App.new(:name => 'test', :environment => 'development', :certificate => 'bad')
+      OpenSSL::X509::Certificate.stub(:new).and_raise(NameError, 'simulating no openssl')
+      expect{app.valid?}.to raise_error(NameError)
+    end
+  end
 end


### PR DESCRIPTION
This may help people with OpenSSL errors, which may be the case reported in #176.
