### PR TITLE
Config to set AR logger to Rapns.logger

### DIFF
--- a/bin/rapns
+++ b/bin/rapns
@@ -34,4 +34,6 @@ load 'config/initializers/rapns.rb' if File.exist?('config/initializers/rapns.rb
 
 Rapns.config.update(config)
 Rapns.require_for_daemon
+ActiveRecord::Base.logger = Rapns.logger if Rapns.config.intercept_active_record_logger
+
 Rapns::Daemon.start

--- a/lib/generators/templates/rapns.rb
+++ b/lib/generators/templates/rapns.rb
@@ -26,6 +26,9 @@
   # Define a custom logger.
   # config.logger = MyLogger.new
 
+  # Set ActiveRecord logger to Rapns.logger.
+  # config.intercept_active_record_logger = false
+
  end
 
 Rapns.reflect do |on|

--- a/lib/rapns/configuration.rb
+++ b/lib/rapns/configuration.rb
@@ -9,7 +9,7 @@ module Rapns
 
   CONFIG_ATTRS = [:foreground, :push_poll, :feedback_poll, :embedded,
     :airbrake_notify, :check_for_errors, :pid_file, :batch_size,
-    :push, :store, :logger, :batch_storage_updates]
+    :push, :store, :logger, :batch_storage_updates, :intercept_active_record_logger]
 
   class ConfigurationWithoutDefaults < Struct.new(*CONFIG_ATTRS)
   end
@@ -80,6 +80,7 @@ module Rapns
       self.store = :active_record
       self.logger = nil
       self.batch_storage_updates = true
+      self.intercept_active_record_logger = false
 
       # Internal options.
       self.embedded = false

--- a/lib/rapns/logger.rb
+++ b/lib/rapns/logger.rb
@@ -27,6 +27,14 @@ module Rapns
       log(:warn, msg, 'WARNING', STDERR)
     end
 
+    def debug(msg)
+      log(:debug, msg)
+    end
+
+    def debug?
+      Rails.configuration.log_level == :debug
+    end
+
     private
 
     def setup_logger(log)


### PR DESCRIPTION
Seeing a Rapns::Notification Load every 2 secs in my dev log when I'm trying to work was getting really distracting :).  So this adds the option to make the ActiveRecord log to Rapns.logger instead.
